### PR TITLE
Implement multi-server support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,8 @@ token_manager.py
 
 config.py
 
-story*
 
-user.txt
-timestamp.txt
 weighted\ list\ of\ users.json
 recent_users.json
+
+storage/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ token_manager.py
 .vscode/
 
 config.py
-
+SQL scripts/
 
 weighted\ list\ of\ users.json
 recent_users.json

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -49,11 +49,9 @@ class dm_listener(commands.Cog):
         """Notifies the current user that it's their turn to add to the story"""
         
         file = await self.file_manager.get_story_file(guild_id)
-        await self.dm_current_user(guild_id, """Your turn.  Respond with a DM to continue the story!  Use a \ to create a line break.
-            
-            **MAKE SURE THE BOT IS ONLINE BEFORE RESPONDING!**  You will get a confirmation response if your story is received.
-            
-            Here is the story so far:""", file = file, embed = create_embed(content=self.lastChars(await self.file_manager.getStory(guild_id)), author_name=None, author_icon_url=None))
+        await self.dm_current_user(guild_id,
+                                   "Your turn.  Respond with a DM to continue the story!  Use a \\ to create a line break.\n\n**MAKE SURE THE BOT IS ONLINE BEFORE RESPONDING!**  You will get a confirmation response if your story is received.\n\nHere is the story so far:",
+                                   file = file, embed = create_embed(content=self.lastChars(await self.file_manager.getStory(guild_id)), author_name=None, author_icon_url=None))
         
         current_user = await self.bot.fetch_user(int(await self.user_manager.get_current_user(guild_id)))
         

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -29,7 +29,7 @@ class dm_listener(commands.Cog):
 
     async def check_for_prefix_command(self, ctx: commands.Context):
         if(await self.config_manager.is_debug_mode() or ctx.author == self.bot.user):
-            pass#return
+            return
         if(ctx.prefix != "/"):
             msg = f"Prefix commands (like what you just ran, `{ctx.message.content}`) no longer work. You'll have to run that as a slash command.\n\nTry running `/{ctx.message.content[len(self.config_manager.get_prefix()):]}`.\n\nSee https://github.com/2br-2b/StoryBot/issues/31 to learn more, and thank you for your patience during this transition!"
             await self.reply_to_message(context=ctx, content=msg, ephemeral=True)

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -273,14 +273,14 @@ class dm_listener(commands.Cog):
     def pieMethod(self, story):
         """The all-powerful pieMethod
         Splits the story into a list of strings if it is too long"""
-        
-        if len(story) >= self.CHARACTERS_TO_SHOW:
+        MAX_MESSAGE_LENGTH = 1950
+        if len(story) >= MAX_MESSAGE_LENGTH:
             split = list()
-            for i in range(math.ceil(len(story) / self.CHARACTERS_TO_SHOW)):
-                if i == math.ceil(len(story) / self.CHARACTERS_TO_SHOW):
+            for i in range(math.ceil(len(story) / MAX_MESSAGE_LENGTH)):
+                if i == math.ceil(len(story) / MAX_MESSAGE_LENGTH):
                     split.append(story[i:len(story) -1])
                 else:
-                    split.append(story[i:i+self.CHARACTERS_TO_SHOW])
+                    split.append(story[i:i+MAX_MESSAGE_LENGTH])
             return split
         else:
             return [story]

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -379,7 +379,7 @@ class dm_listener(commands.Cog):
           
     async def new_user(self, guild_id: int):
         """Chooses a new random user and notifies all relevant parties"""
-        await self.user_manager.set_random_weighted_user(guild_id, add_last_user_to_queue = True)
+        await self.user_manager.set_random_weighted_user(guild_id)
         
         print("New current user: " + await self.user_manager.get_current_user(guild_id))
         await self.file_manager.reset_timestamp(guild_id)

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -50,7 +50,7 @@ class dm_listener(commands.Cog):
         print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Notifies the current user that it's their turn to add to the story"""
         
-        file = discord.File("story.txt", filename="story.txt")
+        file = self.file_manager.get_story_file(guild_id)
         await self.dm_current_user(guild_id, """Your turn.  Respond with a DM to continue the story!  Use a \ to create a line break.
             
             **MAKE SURE THE BOT IS ONLINE BEFORE RESPONDING!**  You will get a confirmation response if your story is received.
@@ -75,21 +75,21 @@ class dm_listener(commands.Cog):
         
         await self.check_for_prefix_command(ctx)
         
-        # TODO: use file_manager.py here
+        proper_guild_id = self.get_proper_guild_id(ctx)
         
         if archived_story_number != 0:
             try:
-                file = discord.File("story {0}.txt".format(archived_story_number), filename="story {0}.txt".format(archived_story_number))
+                file = self.file_manager.get_story_file(proper_guild_id, archived_story_number)
                 title = "Story " + str(archived_story_number)
             except FileNotFoundError:
                 await self.reply_to_message(content='That story number couldn\'t be found!', context=ctx, single_user=True)
                 return
         else:
-            file = discord.File("story.txt", filename="story.txt")
+            file = self.file_manager.get_story_file(proper_guild_id)
             title="The Current Story"
             
         await self.reply_to_message(
-            content=self.lastChars(self.file_manager.getStory(guild_id = self.get_proper_guild_id(ctx), story_number = archived_story_number)),
+            content=self.lastChars(self.file_manager.getStory(guild_id = proper_guild_id, story_number = archived_story_number)),
             title=title, file = file, context=ctx, single_user=True)
 
     @commands.hybrid_command(name="turn")
@@ -222,8 +222,8 @@ class dm_listener(commands.Cog):
                 
                 await self.reply_to_message(message, "Got it!  Thanks!")
                 
-                guild_id_to_use = proper_guild_id
-                self.user_manager.boost_user(guild_id_to_use, int(self.user_manager.get_current_user(guild_id_to_use)))
+                self.user_manager.boost_user(proper_guild_id, int(self.user_manager.get_current_user(proper_guild_id)))
+                
                 await self.new_user(proper_guild_id)
 
     def pieMethod(self, story):

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -146,7 +146,7 @@ class dm_listener(commands.Cog):
         current_user_id = await self.user_manager.get_current_user(proper_guild_id)
         
         if str(ctx.author.id) != current_user_id and not await self.config_manager.is_admin(ctx.author.id, proper_guild_id):
-            await self.reply_to_message(context=ctx, content="It's not your turn!")
+            await self.reply_to_message(context=ctx, content="Nice try :stuck_out_tongue_winking_eye:")
             return
         
         try:

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -20,6 +20,17 @@ class dm_listener(commands.Cog):
         
         self.CHARACTERS_TO_SHOW = 4096
 
+
+    async def check_for_prefix_command(self, ctx: commands.Context, remove = False):
+        if(ctx.prefix != "/"):
+            if(remove):
+                msg = f"Just a heads up: prefix commands (like what you just ran, `{ctx.message.content}`) work for now, but if you choose to use this bot again in the future, you'll need to switch over to slash commands.\n\nTo rejoin, you'll have to run `/add` as opposed to `{config.PREFIX}add`.\n\nSee https://github.com/2br-2b/StoryBot/issues/31 to learn more, and thank you for your patience during this transition!"
+            else:
+                msg = f"Just a heads up: prefix commands (like what you just ran, `{ctx.message.content}`) work for now, but you'll want to switch over to slash commands soon.\n\nIn the future, you'll need to run that command by typing `/{ctx.message.content[len(config.PREFIX):]}`.\n\nSee https://github.com/2br-2b/StoryBot/issues/31 to learn more, and thank you for your patience during this transition!"
+            
+            await (await ctx.author.create_dm()).send(msg)
+
+
     async def dm_current_user(self, message, file = None, embed = None):
         """Sends the given message to the current user"""
         
@@ -55,6 +66,8 @@ class dm_listener(commands.Cog):
         """Sends a reply with the requested story
         If there is a number, the given story number will be returned"""
         
+        await self.check_for_prefix_command(ctx)
+        
         # TODO: use file_manager.py here
         
         if archived_story_number != 0:
@@ -73,6 +86,9 @@ class dm_listener(commands.Cog):
     @commands.hybrid_command(name="turn")
     async def turn(self, ctx: commands.Context):
         """Sends a message with the current user's name"""
+        
+        await self.check_for_prefix_command(ctx)
+        
         current_user = await self.bot.fetch_user(int(self.user_manager.get_current_user()))
         
         #ctx.message.guild.get_member(int(self.user_manager.get_current_user()))
@@ -82,6 +98,8 @@ class dm_listener(commands.Cog):
     @commands.hybrid_command(name="help")
     async def help(self, ctx):
         """The help command"""
+        
+        await self.check_for_prefix_command(ctx)
         
         await self.reply_to_message(context=ctx, 
             content="""This bot is a story bot.  One user will write a part of the story (anywhere from a sentence or two to a couple of paragraphs - your choice!), then another, and so on until the story is complete!
@@ -93,6 +111,8 @@ class dm_listener(commands.Cog):
     @commands.hybrid_command(name="skip")
     async def skip(self, ctx):
         """Skips the current user"""
+        
+        await self.check_for_prefix_command(ctx)
         
         if str(ctx.author.id) != self.user_manager.get_current_user() and not ctx.author.id in config.ADMIN_IDS:
             await self.reply_to_message(context=ctx, content="It's not your turn!")
@@ -111,6 +131,8 @@ class dm_listener(commands.Cog):
     async def notify(self, ctx):
         """The command to notify users that it's their turn"""
         
+        await self.check_for_prefix_command(ctx)
+        
         if not ctx.author.id in config.ADMIN_IDS:
             await self.reply_to_message(context=ctx, content="Only admins can use this command.", single_user=True)
             return
@@ -120,6 +142,9 @@ class dm_listener(commands.Cog):
     @commands.hybrid_command(name="time_left")
     async def time_left_command(self, ctx):
         """Says how much time the current user has remaining"""
+        
+        await self.check_for_prefix_command(ctx)
+        
         seconds_per_turn = config.TIMEOUT_DAYS * 24 * 60 * 60
         timeout_timestamp = int(self.load_timestamp())
         current_time = int(time.time())
@@ -259,12 +284,16 @@ class dm_listener(commands.Cog):
     async def add(self, ctx):
         """Adds a user to the list of participants"""
         
+        await self.check_for_prefix_command(ctx)
+        
         self.user_manager.add_user(ctx.author.id)
         await self.reply_to_message(context=ctx, content="Done!")
 
     @commands.hybrid_command(name="remove")
     async def remove(self, ctx):
         """Removes a user from the list of participants"""
+        
+        await self.check_for_prefix_command(ctx, remove=True)
         
         self.user_manager.remove_user(ctx.author.id)
         await self.reply_to_message(context=ctx, content="Done!")

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -146,7 +146,7 @@ class dm_listener(commands.Cog):
         current_user_id = await self.user_manager.get_current_user(proper_guild_id)
         
         if str(ctx.author.id) != current_user_id and not await self.config_manager.is_admin(ctx.author.id, proper_guild_id):
-            await self.reply_to_message(context=ctx, content="Nice try :stuck_out_tongue_winking_eye:")
+            await self.reply_to_message(context=ctx, content="It's not your turn here!")
             return
         
         try:
@@ -251,7 +251,7 @@ class dm_listener(commands.Cog):
             #self.get_proper_guild_id(message.channel)
             
             if (await self.user_manager.get_current_user(proper_guild_id)) != str(message.author.id):
-                await self.reply_to_message(message=message, content="It's not your turn here!", ephemeral=True)
+                await self.reply_to_message(message=message, content="Nice try :stuck_out_tongue_winking_eye:", ephemeral=True)
                 return
                 
                 

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -59,7 +59,7 @@ class dm_listener(commands.Cog):
         
         file = await self.file_manager.get_story_file(guild_id)
         await self.dm_current_user(guild_id,
-                                   "Your turn.  Respond with a DM to continue the story!  Use a \\ to create a line break.\n\n**MAKE SURE THE BOT IS ONLINE BEFORE RESPONDING!**  You will get a confirmation response if your story is received.\n\nHere is the story so far:",
+                                   "Your turn.  Respond with a DM to continue the story!  Use a \\ to create a line break.\n\nIf you want the next user to continue your sentence, end your story segment with `...`.\n\n**MAKE SURE THE BOT IS ONLINE BEFORE RESPONDING!**  You will get a confirmation response if your story is received.\n\nHere is the story so far:",
                                    file = file, embed = await self.create_embed(content=self.lastChars(await self.file_manager.getStory(guild_id)), author_name=None, author_icon_url=None))
         
         current_user = await self.bot.fetch_user(int(await self.user_manager.get_current_user(guild_id)))

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -428,13 +428,17 @@ class dm_listener(commands.Cog):
             author = message.author
         if not author is None:
             embed.set_author(name=author.name, icon_url=author.display_avatar.url)
-            
-        if not context is None:
-            return await context.send(embed = embed, file = file, mention_author = False, ephemeral=ephemeral, view=view)
-        elif not message is None:
-            return await message.reply(embed = embed, file = file, mention_author = False, view=view)
-        else:
-            raise ValueError("Both ctx and message passed to reply_to_message are None")
+        
+        try:
+            if not context is None:
+                return await context.send(embed = embed, file = file, mention_author = False, ephemeral=ephemeral, view=view)
+            elif not message is None:
+                return await message.reply(embed = embed, file = file, mention_author = False, view=view)
+            else:
+                raise ValueError("Both ctx and message passed to reply_to_message are None")
+        except discord.errors.Forbidden:
+            # TODO: Check for this perm properly
+            pass
           
           
     async def new_user(self, guild_id: int):
@@ -447,7 +451,7 @@ class dm_listener(commands.Cog):
 
     def get_proper_guild_id(self, channel: discord.abc.Messageable) -> int:
         if channel.guild is None:
-            # TODO: figure out how to implement this
+            # TODO: figure out how to implement get_proper_guild_id
             return None
         
         return channel.guild.id

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -37,7 +37,6 @@ class dm_listener(commands.Cog):
 
 
     async def dm_current_user(self, guild_id: int, message, file = None, embed = None):
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Sends the given message to the current user"""
         
         await (await (await self.bot.fetch_user(int(await self.user_manager.get_current_user(guild_id)))).create_dm()).send(message, embed=embed, file = file)
@@ -47,7 +46,6 @@ class dm_listener(commands.Cog):
             
 
     async def notify_people(self, guild_id: int):
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Notifies the current user that it's their turn to add to the story"""
         
         file = await self.file_manager.get_story_file(guild_id)
@@ -251,7 +249,6 @@ class dm_listener(commands.Cog):
             return story
 
     async def timeout_happened(self, guild_id: int):
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Skips the current user's turn if they don't respond in the specified amount of time"""
         
         print('Timing out...') 
@@ -371,7 +368,6 @@ class dm_listener(commands.Cog):
           
           
     async def new_user(self, guild_id: int):
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Chooses a new random user and notifies all relevant parties"""
         await self.user_manager.set_random_weighted_user(guild_id, add_last_user_to_queue = True)
         

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -250,7 +250,8 @@ class dm_listener(commands.Cog):
             #self.get_proper_guild_id(message.channel)
             
             if (await self.user_manager.get_current_user(proper_guild_id)) != str(message.author.id):
-                self.reply_to_message(message=message, content="It's not your turn here!", ephemeral=True)
+                await self.reply_to_message(message=message, content="It's not your turn here!", ephemeral=True)
+                return
                 
                 
             content_to_send = await self.format_story_addition(message.content)

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -223,7 +223,7 @@ class dm_listener(commands.Cog):
                 
                 await self.reply_to_message(message, "Got it!  Thanks!")
                 
-                self.user_manager.boost_user(proper_guild_id, int(await self.user_manager.get_current_user(proper_guild_id)))
+                await self.user_manager.boost_user(proper_guild_id, int(await self.user_manager.get_current_user(proper_guild_id)))
                 
                 await self.new_user(proper_guild_id)
 
@@ -256,7 +256,7 @@ class dm_listener(commands.Cog):
         
         print('Timing out...') 
         await self.dm_current_user(guild_id, 'You took too long!  You\'ll have a chance to add to the story later - don\'t worry!')
-        self.user_manager.unboost_user(guild_id, int(await self.user_manager.get_current_user(guild_id)))
+        await self.user_manager.unboost_user(guild_id, int(await self.user_manager.get_current_user(guild_id)))
         await self.new_user(guild_id)
 
     @tasks.loop(seconds=60 * 60) # Check back every hour
@@ -288,7 +288,7 @@ class dm_listener(commands.Cog):
         
         await self.check_for_prefix_command(ctx)
         
-        self.user_manager.add_user(self.get_proper_guild_id(ctx), ctx.author.id)
+        await self.user_manager.add_user(self.get_proper_guild_id(ctx), ctx.author.id)
         await self.reply_to_message(context=ctx, content="Done!")
 
     @commands.hybrid_command(name="remove")
@@ -304,7 +304,7 @@ class dm_listener(commands.Cog):
         else:
             skip_after = False
         
-        self.user_manager.remove_user(proper_guild, ctx.author.id)
+        await self.user_manager.remove_user(proper_guild, ctx.author.id)
         
         if(skip_after):
             try:

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -449,6 +449,8 @@ class dm_listener(commands.Cog):
             guild_name = self.bot.get_guild(guild_id).name
             server_json.append({"guild id": guild_id, "guild name": guild_name})
         
+        server_json.sort(key=lambda k: k["guild name"])
+        
         view = DropdownView(server_json)
         
         my_message = await self.reply_to_message(message = message, content="Which server should this be added to?", view=view, ephemeral= True)

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -292,12 +292,26 @@ class dm_listener(commands.Cog):
         await self.reply_to_message(context=ctx, content="Done!")
 
     @commands.hybrid_command(name="remove")
-    async def remove(self, ctx):
-        """Removes a user from the list of participants"""
+    async def remove(self, ctx: commands.Context):
+        """Removes a user from the list of participants. If it is their turn, it also skips them"""
         
         await self.check_for_prefix_command(ctx, just_removed=True)
         
-        self.user_manager.remove_user(self.get_proper_guild_id(ctx), ctx.author.id)
+        proper_guild = self.get_proper_guild_id(ctx)
+        
+        if self.user_manager.get_current_user(proper_guild) == str(ctx.author.id):
+            skip_after = True
+        else:
+            skip_after = False
+        
+        self.user_manager.remove_user(proper_guild, ctx.author.id)
+        
+        if(skip_after):
+            try:
+                await self.new_user(proper_guild)
+            except ValueError: #This means that there's no users in the list of users. new_user will return an error but will also set the current user to None.
+                pass
+        
         await self.reply_to_message(context=ctx, content="Done!")
 
     def format_story_addition(self, line:str) -> str:

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -29,10 +29,11 @@ class dm_listener(commands.Cog):
 
     async def check_for_prefix_command(self, ctx: commands.Context):
         if(await self.config_manager.is_debug_mode() or ctx.author == self.bot.user):
-            return
+            pass#return
         if(ctx.prefix != "/"):
-            msg = f"Just a heads up: prefix commands (like what you just ran, `{ctx.message.content}`) work for now, but you'll want to switch over to slash commands soon.\n\nIn the future, you'll need to run that command by typing `/{ctx.message.content[len(self.config_manager.get_prefix()):]}`.\n\nSee https://github.com/2br-2b/StoryBot/issues/31 to learn more, and thank you for your patience during this transition!"
-            await (await ctx.author.create_dm()).send(msg)
+            msg = f"Prefix commands (like what you just ran, `{ctx.message.content}`) no longer work. You'll have to run that as a slash command.\n\nTry running `/{ctx.message.content[len(self.config_manager.get_prefix()):]}`.\n\nSee https://github.com/2br-2b/StoryBot/issues/31 to learn more, and thank you for your patience during this transition!"
+            await self.reply_to_message(context=ctx, content=msg, ephemeral=True)
+            raise Exception("Prefixed command")
 
 
     async def dm_current_user(self, guild_id: int, message, file = None, embed = None):

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -392,6 +392,10 @@ class dm_listener(commands.Cog):
         
         return channel.guild.id
         
+    @commands.is_owner()
+    @commands.hybrid_command(name="register_guild")
+    async def register_guild(self, ctx: commands.Context):
+        await self.file_manager.add_guild(ctx.guild.id)
         
 
         

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -249,7 +249,8 @@ class dm_listener(commands.Cog):
                 
             #self.get_proper_guild_id(message.channel)
             
-            # if await self.user_manager.get_current_user(proper_guild_id) == str(message.author.id)
+            if (await self.user_manager.get_current_user(proper_guild_id)) != str(message.author.id):
+                self.reply_to_message(message=message, content="It's not your turn here!", ephemeral=True)
                 
                 
             content_to_send = await self.format_story_addition(message.content)

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -36,6 +36,7 @@ class dm_listener(commands.Cog):
 
 
     async def dm_current_user(self, guild_id: int, message, file = None, embed = None):
+        print(guild_id)
         """Sends the given message to the current user"""
         
         await (await (await self.bot.fetch_user(int(self.user_manager.get_current_user(guild_id)))).create_dm()).send(message, embed=embed, file = file)
@@ -45,6 +46,7 @@ class dm_listener(commands.Cog):
             
 
     async def notify_people(self, guild_id: int):
+        print(guild_id)
         """Notifies the current user that it's their turn to add to the story"""
         
         file = discord.File("story.txt", filename="story.txt")
@@ -248,6 +250,7 @@ class dm_listener(commands.Cog):
             return story
 
     async def timeout_happened(self, guild_id: int):
+        print(guild_id)
         """Skips the current user's turn if they don't respond in the specified amount of time"""
         
         print('Timing out...') 
@@ -356,6 +359,7 @@ class dm_listener(commands.Cog):
           
           
     async def new_user(self, guild_id: int):
+        print(guild_id)
         """Chooses a new random user and notifies all relevant parties"""
         self.user_manager.set_random_weighted_user(guild_id, add_last_user_to_queue = True)
         

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -62,7 +62,7 @@ class dm_listener(commands.Cog):
             )
         
         # Send a message in the story chanel
-        for channel in config_manager.get_story_announcement_channels(None):
+        for channel in config_manager.get_story_announcement_channels(guild_id):
             await self.bot.get_channel(channel).send(embed = emb)
     
     @commands.hybrid_command(name="story")
@@ -214,7 +214,7 @@ class dm_listener(commands.Cog):
                 
                 current = await self.bot.fetch_user(int(self.user_manager.get_current_user(self.get_proper_guild_id(message.channel))))
                 
-                if config_manager.get_send_story_as_embed(None):
+                if config_manager.get_send_story_as_embed(message.guild.id):
                     content_to_send = None
                     emb = create_embed(
                         author_name=current.name,
@@ -226,7 +226,7 @@ class dm_listener(commands.Cog):
                     emb = None
                 
                 # Mirror the messages to a Discord channel
-                for channel in config_manager.get_story_output_channels(None):
+                for channel in config_manager.get_story_output_channels(message.guild.id):
                     await self.bot.get_channel(channel).send(content_to_send, embed = emb)
                 
                 await self.reply_to_message(message, "Got it!  Thanks!")
@@ -272,7 +272,7 @@ class dm_listener(commands.Cog):
         
         for guild_id in self.file_manager.get_all_guild_ids():
             
-            if time.time() - self.load_timestamp(guild_id) >= 60 * 60 * 24 * config_manager.get_timeout_days(None): # if the time is over the allotted time
+            if time.time() - self.load_timestamp(guild_id) >= 60 * 60 * 24 * config_manager.get_timeout_days(guild_id): # if the time is over the allotted time
                 print('about to timeout for '+self.user_manager.get_current_user(guild_id))
                 await self.timeout_happened(guild_id)
                 print('timeout happened. New user is '+self.user_manager.get_current_user(guild_id))

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -131,9 +131,9 @@ class dm_listener(commands.Cog):
         
         try:
             if(current_user_id != None):
-                await self.file_manager.log_action(self, user_id=int(current_user_id), guild_id=proper_guild_id, action="skip")
+                await self.file_manager.log_action(user_id=int(current_user_id), guild_id=proper_guild_id, action="skip")
             else:
-                await self.file_manager.log_action(self, user_id=0, guild_id=proper_guild_id, action="skip")
+                await self.file_manager.log_action(user_id=0, guild_id=proper_guild_id, action="skip")
             
             await self.new_user(proper_guild_id)
             await self.reply_to_message(context=ctx, content="Skipping :(")
@@ -223,7 +223,7 @@ class dm_listener(commands.Cog):
                     line=content_to_send
                     )
                 
-                await self.file_manager.log_action(self, user_id=message.author.id, guild_id=proper_guild_id, action="add")
+                await self.file_manager.log_action(user_id=message.author.id, guild_id=proper_guild_id, action="add")
                 
                 # Mirror the messages to a Discord channel
                 for channel in config_manager.get_story_output_channels(proper_guild_id):
@@ -265,7 +265,7 @@ class dm_listener(commands.Cog):
         await self.dm_current_user(guild_id, 'You took too long!  You\'ll have a chance to add to the story later - don\'t worry!')
         current_user_id = int(await self.user_manager.get_current_user(guild_id))
         await self.user_manager.unboost_user(guild_id, current_user_id)
-        await self.file_manager.log_action(self, user_id=current_user_id, guild_id=guild_id, action="timeout")
+        await self.file_manager.log_action(user_id=current_user_id, guild_id=guild_id, action="timeout")
         await self.new_user(guild_id)
 
     @tasks.loop(seconds=60 * 60) # Check back every hour

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -18,9 +18,6 @@ class dm_listener(commands.Cog):
         self.user_manager = user_manager
         
         self.bot = bot
-
-        # The timestamp keeps track of when the last user was notified, so that even if the bot goes down, it still knows how much longer the current user has to continue the story
-        self._notif_line_cont = False
         
         self.CHARACTERS_TO_SHOW = 4096
         
@@ -40,10 +37,8 @@ class dm_listener(commands.Cog):
         """Sends the given message to the current user"""
         try:
             await (await (await self.bot.fetch_user(int(await self.user_manager.get_current_user(guild_id)))).create_dm()).send(message, embed=embed, file = file)
-            if self._notif_line_cont:
-                self._notif_line_cont = False
-                await self.dm_current_user(guild_id, "**Please pick up the writing in the middle of the last sentence.**")
-        except discord.ext.commands.errors.HybridCommandError:
+        
+        except discord.ext.commands.errors.HybridCommandError: # Means the user couldn't be DMed
             
             if await self.user_manager.get_current_user(guild_id) == await self.user_manager.get_current_user(guild_id):
                 skip_after = True
@@ -395,7 +390,6 @@ class dm_listener(commands.Cog):
         It also strips any extra spaces at the end of a line and replaces them with a single space"""
         
         if ends_with_continuation_string(line):
-            self._notif_line_cont = True
             return trim_ellipses(line)
         else:
             return add_period_if_missing(line)

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -17,7 +17,6 @@ class dm_listener(commands.Cog):
         self.user_manager = user_manager
         
         self.bot = bot
-        self.messageNotSent = False
 
         # The timestamp keeps track of when the last user was notified, so that even if the bot goes down, it still knows how much longer the current user has to continue the story
         self._notif_line_cont = False
@@ -199,13 +198,8 @@ class dm_listener(commands.Cog):
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
         """Checks if the message should be added the story, and if it is, appends it"""
-        
-        if self.messageNotSent:
-            file = discord.File("story.txt", filename="story.txt")
-            await self.notify_people(self.get_proper_guild_id(message.channel))
-            self.messageNotSent = False
 
-        if message.guild is None:
+        if message.guild is None and message.author != self.bot.user:
             if self.user_manager.get_current_user(self.get_proper_guild_id(message.channel)) == str(message.author.id):
                 if message.content.startswith("/") or message.content.startswith(config_manager.get_prefix()):
                     return

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -370,7 +370,7 @@ class dm_listener(commands.Cog):
     def get_proper_guild_id(self, channel: discord.abc.Messageable) -> int:
         if channel.guild is None:
             # TODO: figure out how to implement this
-            return None
+            return config_manager.get_default_guild_id()
         
         return channel.guild.id
         

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -165,6 +165,10 @@ class dm_listener(commands.Cog):
         """Says how much time the current user has remaining"""
         
         proper_guild_id = self.get_proper_guild_id(ctx)
+        user_id = await self.user_manager.get_current_user(proper_guild_id)
+        if user_id == None:
+            await self.reply_to_message(content="There is no current user. Join the bot to become the first!", context=ctx, ephemeral=True)
+            return
         
         seconds_per_turn = config_manager.get_timeout_days(ctx.guild.id) * 24 * 60 * 60
         timeout_timestamp = int(await self.file_manager.load_timestamp(proper_guild_id))
@@ -172,7 +176,7 @@ class dm_listener(commands.Cog):
         seconds_since_timestamp = current_time - timeout_timestamp
         seconds_remaining = seconds_per_turn - seconds_since_timestamp
         
-        current_user = await self.bot.fetch_user(int(await self.user_manager.get_current_user(proper_guild_id)))
+        current_user = await self.bot.fetch_user(int(user_id))
         
         await self.reply_to_message(context=ctx, content="Time remaining: " + dm_listener.print_time(seconds=seconds_remaining + 60) +"\nTime used: " + dm_listener.print_time(seconds=seconds_since_timestamp)+"", ephemeral=True, author=current_user)
         
@@ -416,7 +420,7 @@ class dm_listener(commands.Cog):
     def get_proper_guild_id(self, channel: discord.abc.Messageable) -> int:
         if channel.guild is None:
             # TODO: figure out how to implement this
-            return config_manager.get_default_guild_id()
+            return None
         
         return channel.guild.id
         

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -127,7 +127,7 @@ class dm_listener(commands.Cog):
         await self.reply_to_message(context=ctx, 
             content="""This bot is a story bot.  One user will write a part of the story (anywhere from a sentence or two to a couple of paragraphs - your choice!), then another, and so on until the story is complete!
             
-    `/add` adds you to the authors, while `/remove` removes you
+    `/join` adds you to the authors, while `/leave` removes you
     `/story` displays the story so far - put a number afterwards to see a past story
     `/turn` displays whose turn it is
     
@@ -137,7 +137,7 @@ class dm_listener(commands.Cog):
     @commands.before_invoke(check_for_prefix_command)
     @commands.hybrid_command(name="skip")
     async def skip(self, ctx: commands.Context):
-        """Skips the current user"""
+        """Skip your turn"""
         
         await self.check_for_prefix_command(ctx)
         
@@ -332,9 +332,9 @@ class dm_listener(commands.Cog):
 
     @commands.guild_only()
     @commands.before_invoke(check_for_prefix_command)
-    @commands.hybrid_command(name="add")
+    @commands.hybrid_command(name="join")
     async def add(self, ctx: commands.Context):
-        """Adds a user to the list of participants"""
+        """Adds you to the list of authors"""
         
         await self.check_for_prefix_command(ctx)
         guild_id = ctx.guild.id
@@ -349,9 +349,9 @@ class dm_listener(commands.Cog):
 
     @commands.guild_only()
     @commands.before_invoke(check_for_prefix_command)
-    @commands.hybrid_command(name="remove")
+    @commands.hybrid_command(name="leave")
     async def remove(self, ctx: commands.Context):
-        """Removes a user from the list of participants. If it is their turn, it also skips them"""
+        """Removes you from the list of authors"""
         
         await self.check_for_prefix_command(ctx)
         

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -472,6 +472,25 @@ class dm_listener(commands.Cog):
             emb.set_author(name=author_name, icon_url=author_icon_url)
         
         return emb
+    
+    @commands.before_invoke(check_for_prefix_command)
+    @commands.hybrid_command(name="my_turns")
+    async def my_turns(self, ctx: commands.Context):
+        """Lists all of the servers where it's currently your turn"""
+        user_current_turns = await self.file_manager.get_current_turns_of_user(ctx.author.id)
+        
+        if len(user_current_turns) < 1:
+            text = "It's not your turn in any servers!"
+        else:
+            text = ""
+            for guild_id in user_current_turns:
+                guild_name = self.bot.get_guild(guild_id).name
+                text += guild_name + "\n"
+            text = text[:-1]
+            
+        await self.reply_to_message(context=ctx, content=text, title=f"{ctx.author.name}'s current turns", ephemeral=True)
+            
+
         
 class DropdownView(discord.ui.View):
     def __init__(self, server_json):

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -1,3 +1,5 @@
+import inspect
+
 import discord
 import math
 import time
@@ -36,7 +38,7 @@ class dm_listener(commands.Cog):
 
 
     async def dm_current_user(self, guild_id: int, message, file = None, embed = None):
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Sends the given message to the current user"""
         
         await (await (await self.bot.fetch_user(int(self.user_manager.get_current_user(guild_id)))).create_dm()).send(message, embed=embed, file = file)
@@ -46,7 +48,7 @@ class dm_listener(commands.Cog):
             
 
     async def notify_people(self, guild_id: int):
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Notifies the current user that it's their turn to add to the story"""
         
         file = discord.File("story.txt", filename="story.txt")
@@ -250,7 +252,7 @@ class dm_listener(commands.Cog):
             return story
 
     async def timeout_happened(self, guild_id: int):
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Skips the current user's turn if they don't respond in the specified amount of time"""
         
         print('Timing out...') 
@@ -265,11 +267,11 @@ class dm_listener(commands.Cog):
         for guild_id in self.file_manager.get_all_guild_ids():
             
             if time.time() - file_manager.load_timestamp(guild_id) >= 60 * 60 * 24 * config_manager.get_timeout_days(guild_id): # if the time is over the allotted time
-                print('about to timeout for '+self.user_manager.get_current_user(guild_id))
+                #print('about to timeout for '+self.user_manager.get_current_user(guild_id))
                 await self.timeout_happened(guild_id)
-                print('timeout happened. New user is '+self.user_manager.get_current_user(guild_id))
+                #print('timeout happened. New user is '+self.user_manager.get_current_user(guild_id))
             
-            print('checked: {0} seconds at {1}'.format(time.time() - file_manager.load_timestamp(guild_id), time.time()))
+            #print('checked: {0} seconds at {1}'.format(time.time() - file_manager.load_timestamp(guild_id), time.time()))
 
 
     @commands.Cog.listener()
@@ -359,7 +361,7 @@ class dm_listener(commands.Cog):
           
           
     async def new_user(self, guild_id: int):
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Chooses a new random user and notifies all relevant parties"""
         self.user_manager.set_random_weighted_user(guild_id, add_last_user_to_queue = True)
         

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -277,7 +277,7 @@ class dm_listener(commands.Cog):
         
         for guild_id in await self.file_manager.get_all_guild_ids():
             
-            if len(await self.user_manager.get_unweighted_list()) >= 2 and time.time() - await self.file_manager.load_timestamp(guild_id) >= 60 * 60 * 24 * config_manager.get_timeout_days(guild_id): # if the time is over the allotted time
+            if len(await self.user_manager.get_unweighted_list(guild_id)) >= 2 and time.time() - await self.file_manager.load_timestamp(guild_id) >= 60 * 60 * 24 * config_manager.get_timeout_days(guild_id): # if the time is over the allotted time
                 await self.timeout_happened(guild_id)
                 
 

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -24,15 +24,11 @@ class dm_listener(commands.Cog):
         self.CHARACTERS_TO_SHOW = 4096
 
 
-    async def check_for_prefix_command(self, ctx: commands.Context, just_removed = False):
-        if(config_manager.is_debug_mode()):
+    async def check_for_prefix_command(self, ctx: commands.Context):
+        if(config_manager.is_debug_mode() or ctx.author == self.bot.user):
             return
         if(ctx.prefix != "/"):
-            if(just_removed):
-                msg = f"Just a heads up: prefix commands (like what you just ran, `{ctx.message.content}`) work for now, but if you choose to use this bot again in the future, you'll need to switch over to slash commands.\n\nTo rejoin, you'll have to run `/add` as opposed to `{config_manager.get_prefix()}add`.\n\nSee https://github.com/2br-2b/StoryBot/issues/31 to learn more, and thank you for your patience during this transition!"
-            else:
-                msg = f"Just a heads up: prefix commands (like what you just ran, `{ctx.message.content}`) work for now, but you'll want to switch over to slash commands soon.\n\nIn the future, you'll need to run that command by typing `/{ctx.message.content[len(config_manager.get_prefix()):]}`.\n\nSee https://github.com/2br-2b/StoryBot/issues/31 to learn more, and thank you for your patience during this transition!"
-            
+            msg = f"Just a heads up: prefix commands (like what you just ran, `{ctx.message.content}`) work for now, but you'll want to switch over to slash commands soon.\n\nIn the future, you'll need to run that command by typing `/{ctx.message.content[len(config_manager.get_prefix()):]}`.\n\nSee https://github.com/2br-2b/StoryBot/issues/31 to learn more, and thank you for your patience during this transition!"
             await (await ctx.author.create_dm()).send(msg)
 
 
@@ -63,6 +59,8 @@ class dm_listener(commands.Cog):
         for channel in config_manager.get_story_announcement_channels(guild_id):
             await self.bot.get_channel(channel).send(embed = emb)
     
+    @commands.guild_only()
+    @commands.before_invoke(check_for_prefix_command)
     @commands.hybrid_command(name="story")
     async def story(self, ctx: commands.Context, archived_story_number:int = 0):
         """Sends a reply with the requested story
@@ -87,6 +85,8 @@ class dm_listener(commands.Cog):
             content=self.lastChars(await self.file_manager.getStory(guild_id = proper_guild_id, story_number = archived_story_number)),
             title=title, file = file, context=ctx, single_user=True)
 
+    @commands.guild_only()
+    @commands.before_invoke(check_for_prefix_command)
     @commands.hybrid_command(name="turn")
     async def turn(self, ctx: commands.Context):
         """Sends a message with the current user's name"""
@@ -111,8 +111,12 @@ class dm_listener(commands.Cog):
             
     `/add` adds you to the authors, while `/remove` removes you
     `/story` displays the story so far - put a number afterwards to see a past story
-    `/turn` displays whose turn it is""", single_user=True)
+    `/turn` displays whose turn it is
+    
+    Note - these commands only work in servers""", single_user=True)
 
+    @commands.guild_only()
+    @commands.before_invoke(check_for_prefix_command)
     @commands.hybrid_command(name="skip")
     async def skip(self, ctx: commands.Context):
         """Skips the current user"""
@@ -139,6 +143,8 @@ class dm_listener(commands.Cog):
         
         
 
+    @commands.guild_only()
+    @commands.before_invoke(check_for_prefix_command)
     @commands.hybrid_command(name="notify")
     async def notify(self, ctx):
         """The command to notify users that it's their turn"""
@@ -151,11 +157,11 @@ class dm_listener(commands.Cog):
         
         await self.notify_people(self.get_proper_guild_id(ctx))
         
+    @commands.guild_only()
+    @commands.before_invoke(check_for_prefix_command)
     @commands.hybrid_command(name="time_left")
     async def time_left_command(self, ctx: commands.Context):
         """Says how much time the current user has remaining"""
-        
-        await self.check_for_prefix_command(ctx)
         
         proper_guild_id = self.get_proper_guild_id(ctx)
         
@@ -288,6 +294,8 @@ class dm_listener(commands.Cog):
     def cog_unload(self):
         self.timeout_checker.cancel()
 
+    @commands.guild_only()
+    @commands.before_invoke(check_for_prefix_command)
     @commands.hybrid_command(name="add")
     async def add(self, ctx: commands.Context):
         """Adds a user to the list of participants"""
@@ -303,6 +311,8 @@ class dm_listener(commands.Cog):
         await self.user_manager.add_user(guild_id, ctx.author.id)
         await self.reply_to_message(context=ctx, content="Done!")
 
+    @commands.guild_only()
+    @commands.before_invoke(check_for_prefix_command)
     @commands.hybrid_command(name="remove")
     async def remove(self, ctx: commands.Context):
         """Removes a user from the list of participants. If it is their turn, it also skips them"""
@@ -397,6 +407,8 @@ class dm_listener(commands.Cog):
         
         return channel.guild.id
         
+    @commands.guild_only()
+    @commands.before_invoke(check_for_prefix_command)
     @commands.is_owner()
     @commands.hybrid_command(name="register_guild")
     async def register_guild(self, ctx: commands.Context):

--- a/cogs/dm_listener.py
+++ b/cogs/dm_listener.py
@@ -70,8 +70,15 @@ class dm_listener(commands.Cog):
             )
         
         # Send a message in the story chanel
-        for channel in await self.config_manager.get_story_announcement_channels(guild_id):
-            await self.bot.get_channel(channel).send(embed = emb)
+        channel_int = await self.config_manager.get_story_announcement_channel(guild_id)
+        if channel_int != None:
+            channel = self.bot.get_channel(channel_int)
+            if channel != None:
+                try:
+                    await channel.send(embed = emb)
+                except discord.errors.Forbidden:
+                    # TODO: Check for this perm properly
+                    pass
     
     @commands.guild_only()
     @commands.before_invoke(check_for_prefix_command)
@@ -261,8 +268,15 @@ class dm_listener(commands.Cog):
             await self.file_manager.log_action(user_id=message.author.id, guild_id=proper_guild_id, action="write")
             
             # Mirror the messages to a Discord channel
-            for channel in await self.config_manager.get_story_output_channels(proper_guild_id):
-                await self.bot.get_channel(channel).send(content_to_send)
+            channel_int = await self.config_manager.get_story_output_channel(proper_guild_id)
+            if channel_int != None:
+                channel = self.bot.get_channel(channel_int)
+                if channel != None:
+                    try:
+                        await channel.send(content_to_send)
+                    except discord.errors.Forbidden:
+                        # TODO: Check for this perm properly
+                        pass
             
             await self.reply_to_message(message, "Got it!  Thanks!")
             

--- a/config.py.default
+++ b/config.py.default
@@ -3,6 +3,14 @@ from discord import Color
 # The bot's Discord token
 TOKEN = 'xxxxxxxxxxxxx'
 
+# Database info
+# This info should point to a PostgreSQL database
+DATABASE_USER="username"
+DATABASE_PASSWORD="password"
+DATABASE_DB_NAME="storybot"
+DATABASE_HOST="0.0.0.0"
+DATABASE_PORT="0000"
+
 # The bot's command prefix
 # Will be phased out eventually in favor of slash commands
 PREFIX = "s."

--- a/config.py.default
+++ b/config.py.default
@@ -20,37 +20,7 @@ TIMEOUT_DAYS = 1
 
 # The default and maximum reputations for a user
 DEFAULT_REPUTATION = 20
-MAX_REPUTATION = 22
-
-# The ID(s) of the channels you want the bot to notify when it's a new player's turn
-# I only use one channel myself, but if you want to use more or split one story across multiple servers, feel free to!
-STORY_CHANNELS = [
-    
-]
-
-# The channels to mirror the story to. Whenever an addition is made to the story, the same text will be mirrored into this channel for easier viewing.
-STORY_OUTPUT_CHANNELS=[
-    
-]
-
-# Whether the story, when sent in STORY_OUTPUT_CHANNELS, should be sent as an embed. If it is sent as an embed, the authors' names will be listed alongside their contributions
-SEND_STORY_AS_EMBED_IN_CHANNEL = False
-
-# The ID(s) of the bot's admin(s)
-ADMIN_IDS = [
-    
-]
-
-# The userIDs to include in the list on the first run
-DEFAULT_USER_IDS = [
-    
-]
+MAX_REPUTATION = 20
 
 # The color to show next to messages the bot sends
 EMBED_COLOR = Color.from_str("0x00ff00")
-
-# The guild the bot will be run in. Will be phased out in the future once multi-server support is added
-GUILD_ID = 0
-
-# The last N people won't be chosen to add to the story again
-LAST_N_PLAYERS_NO_REPEAT = 1

--- a/config.py.default
+++ b/config.py.default
@@ -24,3 +24,6 @@ MAX_REPUTATION = 20
 
 # The color to show next to messages the bot sends
 EMBED_COLOR = Color.from_str("0x00ff00")
+
+# The maximum number of archived stories to let a server have
+MAX_ARCHIVED_STORIES = 10

--- a/config_manager.py
+++ b/config_manager.py
@@ -56,3 +56,12 @@ def get_embed_color() -> Color:
 def get_amount_to_not_repeat() -> int:
     # TODO: Phase out
     return config.LAST_N_PLAYERS_NO_REPEAT
+
+def get_default_guild_id() -> int:
+    return config.GUILD_ID
+
+def is_debug_mode() -> bool:
+    try:
+        return config.DEBUG_MODE
+    except AttributeError:
+        return False

--- a/config_manager.py
+++ b/config_manager.py
@@ -46,11 +46,19 @@ class ConfigManager():
         # TODO: phase out along while adding slash commands
         return config.PREFIX
 
-    async def get_story_announcement_channels(self, guild_id: int) -> list[int]:
-        return [int(await self.file_manager.get_config_value(guild_id, "story_announcement_channel"))]
+    async def get_story_announcement_channel(self, guild_id: int) -> int:
+        channel_id_string = await self.file_manager.get_config_value(guild_id, "story_announcement_channel")
+        if channel_id_string != None:
+            return int(channel_id_string)
+        else:
+            return None
 
-    async def get_story_output_channels(self, guild_id: int) -> list[int]:
-        return [int(await self.file_manager.get_config_value(guild_id, "story_output_channel"))]
+    async def get_story_output_channel(self, guild_id: int) -> int:
+        channel_id_string = await self.file_manager.get_config_value(guild_id, "story_output_channel")
+        if channel_id_string != None:
+            return int(channel_id_string)
+        else:
+            return None
 
     async def is_admin(self, author_id: int, guild_id: int) -> bool:
         return author_id in await self.file_manager.get_admins(guild_id)

--- a/config_manager.py
+++ b/config_manager.py
@@ -29,7 +29,7 @@ def get_default_timeout_days() -> float:
 def get_timeout_days(guild_id: int) -> float:
     return config.TIMEOUT_DAYS
 
-def get_default_reputation(guild_id: int) -> int:
+def get_default_reputation() -> int:
     return config.DEFAULT_REPUTATION
 
 def get_max_reputation() -> int:

--- a/config_manager.py
+++ b/config_manager.py
@@ -23,6 +23,9 @@ def get_token() -> str:
         raise RuntimeError("Please update config.py with your bot's token!")
     return config.TOKEN
 
+def get_default_timeout_days() -> float:
+    return config.TIMEOUT_DAYS
+
 def get_timeout_days(guild_id: int) -> float:
     return config.TIMEOUT_DAYS
 

--- a/config_manager.py
+++ b/config_manager.py
@@ -22,12 +22,15 @@ def get_token() -> str:
     return config.TOKEN
 
 def get_timeout_days(guild_id: int) -> float:
+    print(guild_id)
     return config.TIMEOUT_DAYS
 
 def get_default_reputation(guild_id: int) -> int:
+    print(guild_id)
     return config.DEFAULT_REPUTATION
 
 def get_max_reputation(guild_id: int) -> int:
+    print(guild_id)
     return config.MAX_REPUTATION
 
 def get_prefix() -> str:
@@ -35,12 +38,15 @@ def get_prefix() -> str:
     return config.PREFIX
 
 def get_story_announcement_channels(guild_id: int) -> list[int]:
+    print(guild_id)
     return config.STORY_CHANNELS
 
 def get_story_output_channels(guild_id: int) -> list[int]:
+    print(guild_id)
     return config.STORY_OUTPUT_CHANNELS
 
 def is_admin(author_id: int, guild_id: int) -> bool:
+    print(guild_id)
     return author_id in config.ADMIN_IDS
 
 def get_default_user_ids() -> list[int]:

--- a/config_manager.py
+++ b/config_manager.py
@@ -24,15 +24,15 @@ def get_token() -> str:
     return config.TOKEN
 
 def get_timeout_days(guild_id: int) -> float:
-    print(str(guild_id) + ": " + inspect.stack()[1][3])
+    # print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.TIMEOUT_DAYS
 
 def get_default_reputation(guild_id: int) -> int:
-    print(str(guild_id) + ": " + inspect.stack()[1][3])
+    # print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.DEFAULT_REPUTATION
 
 def get_max_reputation(guild_id: int) -> int:
-    print(str(guild_id) + ": " + inspect.stack()[1][3])
+    # print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.MAX_REPUTATION
 
 def get_prefix() -> str:
@@ -40,15 +40,15 @@ def get_prefix() -> str:
     return config.PREFIX
 
 def get_story_announcement_channels(guild_id: int) -> list[int]:
-    print(str(guild_id) + ": " + inspect.stack()[1][3])
+    # print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.STORY_CHANNELS
 
 def get_story_output_channels(guild_id: int) -> list[int]:
-    print(str(guild_id) + ": " + inspect.stack()[1][3])
+    # print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.STORY_OUTPUT_CHANNELS
 
 def is_admin(author_id: int, guild_id: int) -> bool:
-    print(str(guild_id) + ": " + inspect.stack()[1][3])
+    # print(str(guild_id) + ": " + inspect.stack()[1][3])
     return author_id in config.ADMIN_IDS
 
 def get_default_user_ids() -> list[int]:
@@ -70,3 +70,19 @@ def is_debug_mode() -> bool:
         return config.DEBUG_MODE
     except AttributeError:
         return False
+    
+        
+def get_database_user() -> str:
+    return config.DATABASE_USER
+
+def get_database_password() -> str:
+    return config.DATABASE_PASSWORD
+
+def get_database_name() -> str:
+    return config.DATABASE_DB_NAME
+
+def get_database_host() -> str:
+    return config.DATABASE_HOST
+
+def get_database_port() -> str:
+    return config.DATABASE_PORT

--- a/config_manager.py
+++ b/config_manager.py
@@ -1,0 +1,58 @@
+try:
+    import config
+except ModuleNotFoundError:
+    # Check if the file exists
+    # If it doesn't, copy the example file
+    from os.path import exists
+    if not exists("config.py"):
+        import shutil
+        shutil.copyfile("config.py.default", "config.py")
+        print("Please edit your config file (config.py) and then restart the bot.")
+        exit()
+    else:
+        print("Something went wrong importing the config file. Check your config file for any errors, then restart the bot.")
+        exit()
+        
+        
+from discord import Color
+
+def get_token() -> str:
+    if(config.TOKEN == 'xxxxxxxxxxxxx'):
+        raise RuntimeError("Please update config.py with your bot's token!")
+    return config.TOKEN
+
+def get_timeout_days(guild_id: int) -> float:
+    return config.TIMEOUT_DAYS
+
+def get_default_reputation(guild_id: int) -> int:
+    return config.DEFAULT_REPUTATION
+
+def get_max_reputation(guild_id: int) -> int:
+    return config.MAX_REPUTATION
+
+def get_prefix() -> str:
+    # TODO: phase out along while adding slash commands
+    return config.PREFIX
+
+def get_story_announcement_channels(guild_id: int) -> list(int):
+    return config.STORY_CHANNELS
+
+def get_story_output_channels(guild_id: int) -> list(int):
+    return config.STORY_OUTPUT_CHANNELS
+
+def get_send_story_as_embed(guild_id: int) -> bool:
+    return config.SEND_STORY_AS_EMBED_IN_CHANNEL
+
+def is_admin(author_id: int, guild_id: int) -> bool:
+    return author_id in config.ADMIN_IDS
+
+def get_default_user_ids() -> list(int):
+    # TODO: Phase out
+    return config.DEFAULT_USER_IDS
+
+def get_embed_color() -> Color:
+    return config.EMBED_COLOR
+
+def get_amount_to_not_repeat() -> int:
+    # TODO: Phase out
+    return config.LAST_N_PLAYERS_NO_REPEAT

--- a/config_manager.py
+++ b/config_manager.py
@@ -1,3 +1,5 @@
+import inspect
+
 try:
     import config
 except ModuleNotFoundError:
@@ -22,15 +24,15 @@ def get_token() -> str:
     return config.TOKEN
 
 def get_timeout_days(guild_id: int) -> float:
-    print(guild_id)
+    print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.TIMEOUT_DAYS
 
 def get_default_reputation(guild_id: int) -> int:
-    print(guild_id)
+    print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.DEFAULT_REPUTATION
 
 def get_max_reputation(guild_id: int) -> int:
-    print(guild_id)
+    print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.MAX_REPUTATION
 
 def get_prefix() -> str:
@@ -38,15 +40,15 @@ def get_prefix() -> str:
     return config.PREFIX
 
 def get_story_announcement_channels(guild_id: int) -> list[int]:
-    print(guild_id)
+    print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.STORY_CHANNELS
 
 def get_story_output_channels(guild_id: int) -> list[int]:
-    print(guild_id)
+    print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.STORY_OUTPUT_CHANNELS
 
 def is_admin(author_id: int, guild_id: int) -> bool:
-    print(guild_id)
+    print(str(guild_id) + ": " + inspect.stack()[1][3])
     return author_id in config.ADMIN_IDS
 
 def get_default_user_ids() -> list[int]:

--- a/config_manager.py
+++ b/config_manager.py
@@ -58,9 +58,6 @@ class ConfigManager():
     async def get_embed_color(self) -> Color:
         return config.EMBED_COLOR
 
-    async def get_default_guild_id(self) -> int:
-        return config.GUILD_ID
-
     async def is_debug_mode(self) -> bool:
         try:
             return config.DEBUG_MODE

--- a/config_manager.py
+++ b/config_manager.py
@@ -40,9 +40,6 @@ def get_story_announcement_channels(guild_id: int) -> list[int]:
 def get_story_output_channels(guild_id: int) -> list[int]:
     return config.STORY_OUTPUT_CHANNELS
 
-def get_send_story_as_embed(guild_id: int) -> bool:
-    return config.SEND_STORY_AS_EMBED_IN_CHANNEL
-
 def is_admin(author_id: int, guild_id: int) -> bool:
     return author_id in config.ADMIN_IDS
 

--- a/config_manager.py
+++ b/config_manager.py
@@ -24,15 +24,12 @@ def get_token() -> str:
     return config.TOKEN
 
 def get_timeout_days(guild_id: int) -> float:
-    # print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.TIMEOUT_DAYS
 
 def get_default_reputation(guild_id: int) -> int:
-    # print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.DEFAULT_REPUTATION
 
 def get_max_reputation() -> int:
-    # print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.MAX_REPUTATION
 
 def get_prefix() -> str:
@@ -40,15 +37,12 @@ def get_prefix() -> str:
     return config.PREFIX
 
 def get_story_announcement_channels(guild_id: int) -> list[int]:
-    # print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.STORY_CHANNELS
 
 def get_story_output_channels(guild_id: int) -> list[int]:
-    # print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.STORY_OUTPUT_CHANNELS
 
 def is_admin(author_id: int, guild_id: int) -> bool:
-    # print(str(guild_id) + ": " + inspect.stack()[1][3])
     return author_id in config.ADMIN_IDS
 
 def get_default_user_ids() -> list[int]:

--- a/config_manager.py
+++ b/config_manager.py
@@ -18,68 +18,66 @@ except ModuleNotFoundError:
         
 from discord import Color
 
-def get_token() -> str:
-    if(config.TOKEN == 'xxxxxxxxxxxxx'):
-        raise RuntimeError("Please update config.py with your bot's token!")
-    return config.TOKEN
+class ConfigManager():
+    def __init__(self, file_manager) -> None:
+        self.set_file_manager(file_manager)
 
-def get_default_timeout_days() -> float:
-    return config.TIMEOUT_DAYS
+    def set_file_manager(self, file_manager) -> None:
+        self.file_manager = file_manager
 
-def get_timeout_days(guild_id: int) -> float:
-    return config.TIMEOUT_DAYS
+    def get_token(self) -> str:
+        if(config.TOKEN == 'xxxxxxxxxxxxx'):
+            raise RuntimeError("Please update config.py with your bot's token!")
+        return config.TOKEN
 
-def get_default_reputation() -> int:
-    return config.DEFAULT_REPUTATION
+    async def get_default_timeout_days(self) -> float:
+        return config.TIMEOUT_DAYS
 
-def get_max_reputation() -> int:
-    return config.MAX_REPUTATION
+    async def get_timeout_days(self, guild_id: int) -> float:
+        return config.TIMEOUT_DAYS
 
-def get_prefix() -> str:
-    # TODO: phase out along while adding slash commands
-    return config.PREFIX
+    async def get_default_reputation(self) -> int:
+        return config.DEFAULT_REPUTATION
 
-def get_story_announcement_channels(guild_id: int) -> list[int]:
-    return config.STORY_CHANNELS
+    async def get_max_reputation(self) -> int:
+        return config.MAX_REPUTATION
 
-def get_story_output_channels(guild_id: int) -> list[int]:
-    return config.STORY_OUTPUT_CHANNELS
+    def get_prefix(self) -> str:
+        # TODO: phase out along while adding slash commands
+        return config.PREFIX
 
-def is_admin(author_id: int, guild_id: int) -> bool:
-    return author_id in config.ADMIN_IDS
+    async def get_story_announcement_channels(self, guild_id: int) -> list[int]:
+        return [int(await self.file_manager.get_config_value(guild_id, "story_announcement_channel"))]
 
-def get_default_user_ids() -> list[int]:
-    # TODO: Phase out
-    return config.DEFAULT_USER_IDS
+    async def get_story_output_channels(self, guild_id: int) -> list[int]:
+        return [int(await self.file_manager.get_config_value(guild_id, "story_output_channel"))]
 
-def get_embed_color() -> Color:
-    return config.EMBED_COLOR
+    async def is_admin(self, author_id: int, guild_id: int) -> bool:
+        return author_id in await self.file_manager.get_admins(guild_id)
 
-def get_amount_to_not_repeat() -> int:
-    # TODO: Phase out
-    return config.LAST_N_PLAYERS_NO_REPEAT
+    async def get_embed_color(self) -> Color:
+        return config.EMBED_COLOR
 
-def get_default_guild_id() -> int:
-    return config.GUILD_ID
+    async def get_default_guild_id(self) -> int:
+        return config.GUILD_ID
 
-def is_debug_mode() -> bool:
-    try:
-        return config.DEBUG_MODE
-    except AttributeError:
-        return False
-    
+    async def is_debug_mode(self) -> bool:
+        try:
+            return config.DEBUG_MODE
+        except AttributeError:
+            return False
         
-def get_database_user() -> str:
-    return config.DATABASE_USER
+    async def get_database_user(self) -> str:
+        return config.DATABASE_USER
 
-def get_database_password() -> str:
-    return config.DATABASE_PASSWORD
+    async def get_database_password(self) -> str:
+        return config.DATABASE_PASSWORD
 
-def get_database_name() -> str:
-    return config.DATABASE_DB_NAME
+    async def get_database_name(self) -> str:
+        return config.DATABASE_DB_NAME
 
-def get_database_host() -> str:
-    return config.DATABASE_HOST
+    async def get_database_host(self) -> str:
+        return config.DATABASE_HOST
 
-def get_database_port() -> str:
-    return config.DATABASE_PORT
+    async def get_database_port(self) -> str:
+        return config.DATABASE_PORT

--- a/config_manager.py
+++ b/config_manager.py
@@ -34,10 +34,10 @@ def get_prefix() -> str:
     # TODO: phase out along while adding slash commands
     return config.PREFIX
 
-def get_story_announcement_channels(guild_id: int) -> list(int):
+def get_story_announcement_channels(guild_id: int) -> list[int]:
     return config.STORY_CHANNELS
 
-def get_story_output_channels(guild_id: int) -> list(int):
+def get_story_output_channels(guild_id: int) -> list[int]:
     return config.STORY_OUTPUT_CHANNELS
 
 def get_send_story_as_embed(guild_id: int) -> bool:
@@ -46,7 +46,7 @@ def get_send_story_as_embed(guild_id: int) -> bool:
 def is_admin(author_id: int, guild_id: int) -> bool:
     return author_id in config.ADMIN_IDS
 
-def get_default_user_ids() -> list(int):
+def get_default_user_ids() -> list[int]:
     # TODO: Phase out
     return config.DEFAULT_USER_IDS
 

--- a/config_manager.py
+++ b/config_manager.py
@@ -86,3 +86,9 @@ class ConfigManager():
 
     async def get_database_port(self) -> str:
         return config.DATABASE_PORT
+    
+    async def get_max_archived_stories(self) -> int:
+        try:
+            return config.MAX_ARCHIVED_STORIES
+        except AttributeError:
+            return 10

--- a/config_manager.py
+++ b/config_manager.py
@@ -31,7 +31,7 @@ def get_default_reputation(guild_id: int) -> int:
     # print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.DEFAULT_REPUTATION
 
-def get_max_reputation(guild_id: int) -> int:
+def get_max_reputation() -> int:
     # print(str(guild_id) + ": " + inspect.stack()[1][3])
     return config.MAX_REPUTATION
 

--- a/file_manager.py
+++ b/file_manager.py
@@ -211,6 +211,17 @@ class file_manager():
         # - Manually skipping (`skip`)
         # - Timing out (`timeout`)
         await self.db_connection.execute(f"INSERT INTO \"Logs\" (user_id, guild_id, action) VALUES ('{user_id}', '{guild_id}', '{action}')")
+        
+        
+    async def get_recent_users_queue(self, guild_id: int) -> list[int]:
+        user_count = len(await self.get_active_users(guild_id))
+        recent_users_to_skip = user_count // 2
+        results = await self.db_connection.fetch(f"select user_id from \"Logs\" where guild_id = '{guild_id}' order by timestamp DESC limit {recent_users_to_skip}")
+        
+        return [int(i.get("user_id")) for i in results]
+        
+        
+        
 
 @staticmethod
 def _get_story_file_name(guild_id: int, story_number: int = 0) -> str:

--- a/file_manager.py
+++ b/file_manager.py
@@ -87,12 +87,16 @@ class file_manager():
         
     
     async def get_current_user_id(self,  guild_id: int) -> str:
-        result = await self.db_connection.fetchrow(f"select current_user_id from \"Guilds\" where guild_id = '{guild_id}'")
-        return result.get("current_user_id")
+        result = (await self.db_connection.fetchrow(f"select current_user_id from \"Guilds\" where guild_id = '{guild_id}'")).get("current_user_id")
+        if result == "0":
+            return None
+        return result
     
 
     async def set_current_user_id(self,  guild_id: int, user_id: int) -> str:
         """Sets the current user for a given guild"""
+        if user_id == None:
+            user_id = 0
         await self.db_connection.execute(f"UPDATE \"Guilds\" SET current_user_id='{user_id}' WHERE guild_id='{guild_id}'")
         return str(user_id)
         

--- a/file_manager.py
+++ b/file_manager.py
@@ -7,7 +7,7 @@ class file_manager():
         file = open("story.txt", "r", encoding="utf8")
         file.close()
 
-    def getStory(self, story_number = 0):
+    def getStory(self, guild_id: int, story_number = 0):
         """Returns the story in the story.txt file"""
         if story_number == 0:
             with open("story.txt", "r", encoding="utf8") as file:
@@ -16,7 +16,7 @@ class file_manager():
             with open("story " + str(story_number) + ".txt", "r", encoding="utf8") as file:
                 return file.read()
 
-    def addLine(self, line):
+    def addLine(self, guild_id: int, line):
         """Appends the given line to the story and writes it to the file"""
         
         # Makes sure the bot isn't trying to append a command onto the story
@@ -31,7 +31,7 @@ class file_manager():
             self.story = f.read()
 
     @staticmethod
-    def new_story(self):
+    def new_story(self, guild_id: int):
         """A work in progress
         Should save the old story and restart the current story from scratch"""
         raise NotImplementedError("The `file_manager.new_story()` command is not finished yet.")
@@ -41,7 +41,7 @@ class file_manager():
 
         time.sleep(0.01)
 
-        backup_filename = file_manager.find_next_available_filename()
+        backup_filename = file_manager.find_next_available_filename(guild_id)
 
         with open(backup_filename, 'w') as f:
             f.write(str(old_story))
@@ -50,10 +50,14 @@ class file_manager():
             f.write('')
 
     @staticmethod
-    def find_next_available_filename() -> str:
+    def find_next_available_filename(guild_id: int) -> str:
         """This method finds the next available name for a story file and returns it"""
         i = 1
         while os.file.exists(f"story {i}.txt"):
             i += 1
 
         return f"story {i}.txt"
+
+    def get_all_guild_ids(self) -> list[int]:
+        # TODO: not implemented
+        return [ 00000000 ]

--- a/file_manager.py
+++ b/file_manager.py
@@ -1,11 +1,14 @@
 import os
 import time
 import config_manager
+from pathlib import Path
 
 class file_manager():
     def __init__(self):
-        file = open("story.txt", "r", encoding="utf8")
-        file.close()
+
+        if not Path("story.txt").is_file():
+            print("Created story.txt")
+            open("story.txt", "x").close()
 
     def getStory(self, guild_id: int, story_number = 0):
         """Returns the story in the story.txt file"""
@@ -66,3 +69,30 @@ class file_manager():
     def get_all_guild_ids(self) -> list[int]:
         # TODO: not implemented
         return [ config_manager.get_default_guild_id() ]
+
+
+
+
+
+@staticmethod
+def load_timestamp(guild_id: int, filename: str = "timestamp.txt") -> float:
+    """Returns the timestamp if it exists. If it doesn't, it'll reset the timestamp and return the new one."""
+
+    try:
+        with open(filename, "r") as f:
+            return float(f.read())
+    except FileNotFoundError:
+        print("Timestamp not found. Resetting timestamp...")
+        reset_timestamp(guild_id)
+        return load_timestamp(guild_id)
+    except ValueError:
+        reset_timestamp(guild_id)
+        raise RuntimeWarning("Timestamp has been corrupted. I have reset the timestamp, but if this keeps happening, something's wrong.")
+
+@staticmethod
+def reset_timestamp(guild_id: int, filename:str = "timestamp.txt") -> float:
+    """Resets the timestamp to the current time"""
+    now = time.time()
+    with open(filename, "w") as f:
+        f.write(str(now))
+    return now

--- a/file_manager.py
+++ b/file_manager.py
@@ -31,7 +31,8 @@ class file_manager():
         return guild_id in await self.get_all_guild_ids()
     
     async def add_guild(self, guild_id: int) -> None:
-        await self.db_connection.execute(f"INSERT INTO \"Guilds\" (guild_id, timeout_days) VALUES ('{guild_id}, {config_manager.get_timeout_days()}')")
+        if not guild_id in await self.get_all_guild_ids():
+            await self.db_connection.execute(f"INSERT INTO \"Guilds\" (guild_id, timeout_days) VALUES ('{guild_id}', '{config_manager.get_default_timeout_days()}')")
     
     async def getStory(self, guild_id: int, story_number = 0) -> str:
         """Returns the story in the story.txt file"""
@@ -132,7 +133,7 @@ class file_manager():
         result = [int(i.get("guild_id")) for i in result]
         return result
     
-    async def get_active_guilds(self, user_id: int) -> list[int]:
+    async def get_user_active_guilds(self, user_id: int) -> list[int]:
         """Returns all servers where a user is active
 
         Args:

--- a/file_manager.py
+++ b/file_manager.py
@@ -1,3 +1,5 @@
+import inspect
+
 import os
 import time
 import config_manager
@@ -11,7 +13,7 @@ class file_manager():
             open("story.txt", "x").close()
 
     def getStory(self, guild_id: int, story_number = 0):
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Returns the story in the story.txt file"""
         if story_number == 0:
             with open("story.txt", "r", encoding="utf8") as file:
@@ -26,7 +28,7 @@ class file_manager():
             return text
 
     def addLine(self, guild_id: int, line):
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Appends the given line to the story and writes it to the file"""
         
         # Makes sure the bot isn't trying to append a command onto the story
@@ -42,7 +44,7 @@ class file_manager():
 
     @staticmethod
     def new_story(self, guild_id: int):
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """A work in progress
         Should save the old story and restart the current story from scratch"""
         raise NotImplementedError("The `file_manager.new_story()` command is not finished yet.")
@@ -62,7 +64,7 @@ class file_manager():
 
     @staticmethod
     def find_next_available_filename(guild_id: int) -> str:
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """This method finds the next available name for a story file and returns it"""
         i = 1
         while os.file.exists(f"story {i}.txt"):
@@ -80,7 +82,7 @@ class file_manager():
 
 @staticmethod
 def load_timestamp(guild_id: int, filename: str = "timestamp.txt") -> float:
-    print(guild_id)
+    print(str(guild_id) + ": " + inspect.stack()[1][3])
     """Returns the timestamp if it exists. If it doesn't, it'll reset the timestamp and return the new one."""
 
     try:
@@ -96,7 +98,7 @@ def load_timestamp(guild_id: int, filename: str = "timestamp.txt") -> float:
 
 @staticmethod
 def reset_timestamp(guild_id: int, filename:str = "timestamp.txt") -> float:
-    print(guild_id)
+    print(str(guild_id) + ": " + inspect.stack()[1][3])
     """Resets the timestamp to the current time"""
     now = time.time()
     with open(filename, "w") as f:

--- a/file_manager.py
+++ b/file_manager.py
@@ -5,23 +5,51 @@ import time
 import config_manager
 from pathlib import Path
 import discord.file
+import json
 
-class file_manager():
+class file_manager():     
+    def __init__(self) -> None:
+        filepath = "storage/active_servers.json"
+        if not os.path.isfile(filepath):
+            os.makedirs("storage/archive")
+            with open(filepath, "w+") as f:
+                json.dump([], f, indent=4)
+        
+        self.initialize_server(config_manager.get_default_guild_id())
+    
+    def is_active_server(self, guild_id: int) -> bool:
+        """Returns if a guild is currently participating in StoryBot"""
+        with open('storage/active_servers.json', 'r') as f:
+            return guild_id in json.load(f)
+    
+    def initialize_server(self,  guild_id: int) -> None:
+        if not self.is_active_server(guild_id):
+            self.reset_timestamp(guild_id)
+            self.addLine(guild_id, "")
+            self.set_current_user_id(guild_id, None)
+            
+            with open('storage/active_servers.json', 'r') as f:
+                active_guilds = json.load(f)
+            active_guilds.append(guild_id)
+            os.remove("storage/active_servers.json")
+            with open('storage/active_servers.json', 'w') as f:
+                json.dump(active_guilds, f, indent=4)
+        
     def getStory(self, guild_id: int, story_number = 0) -> str:
         print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Returns the story in the story.txt file"""
-        if story_number == 0:
-            story_file_name = "story.txt"
-        else:
-            story_file_name = "story " + str(story_number) + ".txt"
-            
-            
+        
+        story_file_name = _get_story_file_name(guild_id, story_number)
+        
         try:
             with open(story_file_name, "r", encoding="utf8") as file:
                 text = file.read() 
-        except FileNotFoundError:
-            Path(story_file_name).touch()
-            return self.getStory(guild_id, story_number)
+        except FileNotFoundError as e:
+            if story_number == 0:
+                Path(story_file_name).touch()
+                return self.getStory(guild_id, story_number)
+            else:
+                raise e
         
         if(text == ""):
             return "<Waiting for the first user to begin!>"
@@ -30,17 +58,17 @@ class file_manager():
        
     def get_story_file(self, guild_id: int, story_number = 0) -> discord.file:
         
-        if story_number == 0:
-            story_file_name = "story.txt"
-        else:
-            story_file_name = "story " + str(story_number) + ".txt"
+        story_file_name = _get_story_file_name(guild_id, story_number)
         
         try:
-            return discord.File(story_file_name, filename=story_file_name)
-        except FileNotFoundError:
-            Path(story_file_name).touch()
-            return self.get_story_file(guild_id, story_number)
-                
+            return discord.File(story_file_name, filename="Story.txt")
+        except FileNotFoundError as e:
+            if story_number == 0:
+                Path(story_file_name).touch()
+                return self.get_story_file(guild_id, story_number)
+            else:
+                raise e
+
 
     def addLine(self, guild_id: int, line):
         print(str(guild_id) + ": " + inspect.stack()[1][3])
@@ -51,42 +79,64 @@ class file_manager():
         if line.startswith(config_manager.get_prefix()):
             raise RuntimeWarning("I was just told to add this to the story, but this is clearly a command:\n"+line)
         
-        with open("story.txt", "a+", encoding="utf8") as append_to:
+        with open(_get_story_file_name(guild_id), "a+", encoding="utf8") as append_to:
             append_to.write(line)
-
-        with open("story.txt", "r", encoding="utf8") as f:
-            self.story = f.read()
 
 
     def get_all_guild_ids(self) -> list[int]:
-        # TODO: not implemented
-        return [ config_manager.get_default_guild_id() ]
+        with open('storage/active_servers.json', 'r') as f:
+            return json.load(f)
+    
+    def get_current_user_id(self,  guild_id: int) -> str:
+        try:
+            with open(_get_current_user_file_name(guild_id)) as f:
+                return f.read()
+        except FileNotFoundError:
+            return None
 
+    def set_current_user_id(self,  guild_id: int, user_id: int) -> str:
+        if user_id is None:
+            user_id = ""
+        with open(_get_current_user_file_name(guild_id), 'w+') as f:
+            f.write(str(user_id))
+        
+        
+    def load_timestamp(self,  guild_id: int) -> float:
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
+        """Returns the timestamp if it exists. If it doesn't, it'll reset the timestamp and return the new one."""
 
+        try:
+            with open(_get_timestamp_file_name(guild_id), "r") as f:
+                return float(f.read())
+        except FileNotFoundError:
+            print("Timestamp not found. Resetting timestamp...")
+            self.reset_timestamp(guild_id)
+            return self.load_timestamp(guild_id)
+        except ValueError:
+            self.reset_timestamp(guild_id)
+            raise RuntimeWarning("Timestamp has been corrupted. I have reset the timestamp, but if this keeps happening, something's wrong.")
 
+    def reset_timestamp(self,  guild_id: int) -> float:
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
+        """Resets the timestamp to the current time"""
+        now = time.time()
+        with open(_get_timestamp_file_name(guild_id), "w+") as f:
+            f.write(str(now))
+        return now
 
+    
+@staticmethod
+def _get_story_file_name(guild_id: int, story_number: int = 0) -> str:
+    if story_number == 0:
+        story_file_name = f"storage/{guild_id} story.txt"
+    else:
+        story_file_name = f"storage/archive/{guild_id} archived story {str(story_number)}.txt"
+    return story_file_name
 
 @staticmethod
-def load_timestamp(guild_id: int, filename: str = "timestamp.txt") -> float:
-    print(str(guild_id) + ": " + inspect.stack()[1][3])
-    """Returns the timestamp if it exists. If it doesn't, it'll reset the timestamp and return the new one."""
-
-    try:
-        with open(filename, "r") as f:
-            return float(f.read())
-    except FileNotFoundError:
-        print("Timestamp not found. Resetting timestamp...")
-        reset_timestamp(guild_id)
-        return load_timestamp(guild_id)
-    except ValueError:
-        reset_timestamp(guild_id)
-        raise RuntimeWarning("Timestamp has been corrupted. I have reset the timestamp, but if this keeps happening, something's wrong.")
+def _get_timestamp_file_name(guild_id: int) -> str:
+    return f"storage/{guild_id} timestamp.txt"
 
 @staticmethod
-def reset_timestamp(guild_id: int, filename:str = "timestamp.txt") -> float:
-    print(str(guild_id) + ": " + inspect.stack()[1][3])
-    """Resets the timestamp to the current time"""
-    now = time.time()
-    with open(filename, "w+") as f:
-        f.write(str(now))
-    return now
+def _get_current_user_file_name(guild_id: int) -> str:
+    return f"storage/{guild_id} user.txt"

--- a/file_manager.py
+++ b/file_manager.py
@@ -11,10 +11,15 @@ class file_manager():
         """Returns the story in the story.txt file"""
         if story_number == 0:
             with open("story.txt", "r", encoding="utf8") as file:
-                return file.read()
+                text = file.read() 
         else:
             with open("story " + str(story_number) + ".txt", "r", encoding="utf8") as file:
-                return file.read()
+                text = file.read()
+        
+        if(text == ""):
+            return "<Waiting for the first user to begin!>"
+        else:
+            return text
 
     def addLine(self, guild_id: int, line):
         """Appends the given line to the story and writes it to the file"""
@@ -60,4 +65,4 @@ class file_manager():
 
     def get_all_guild_ids(self) -> list[int]:
         # TODO: not implemented
-        return [ 00000000 ]
+        return [ config_manager.get_default_guild_id() ]

--- a/file_manager.py
+++ b/file_manager.py
@@ -120,6 +120,35 @@ class file_manager():
         q=datetime.now().isoformat(sep=" ", timespec="seconds")
         
         await self.db_connection.execute(f"UPDATE \"Guilds\" SET timestamp='{q}' WHERE guild_id='{guild_id}'")
+        
+    async def get_current_turns_of_user(self, user_id: int) -> list[int]:
+        # print(str(guild_id) + ": " + inspect.stack()[1][3])
+        """Returns all servers where it is a user's turn
+
+        Args:
+            user_id (int): the user id to check for
+
+        Returns:
+            list[int]: a list with all of the user's current turns
+        """
+        result = (await self.db_connection.fetch(f"select guild_id from \"Guilds\" where user_id = '{user_id}'"))
+        result = [int(i.get("guild_id")) for i in result]
+        return result
+    
+    async def get_active_guilds(self, user_id: int) -> list[int]:
+        # print(str(guild_id) + ": " + inspect.stack()[1][3])
+        """Returns all servers where a user is active
+
+        Args:
+            user_id (int): the user id to check for
+
+        Returns:
+            list[int]: a list with all of the user's servers
+        """
+        result = (await self.db_connection.fetch(f"select guild_id from \"Users\" where user_id = '{user_id}'"))
+        result = [int(i.get("guild_id")) for i in result]
+        return result
+        
 
 @staticmethod
 def _get_story_file_name(guild_id: int, story_number: int = 0) -> str:

--- a/file_manager.py
+++ b/file_manager.py
@@ -34,7 +34,7 @@ class file_manager():
     
     async def add_guild(self, guild_id: int) -> None:
         if not guild_id in await self.get_all_guild_ids():
-            await self.db_connection.execute(f"INSERT INTO \"Guilds\" (guild_id, timeout_days) VALUES ('{guild_id}', '{await self.config_manager.get_default_timeout_days()}')")
+            await self.db_connection.execute(f"INSERT INTO \"Guilds\" (guild_id, timeout_days) VALUES ('{guild_id}', {await self.config_manager.get_default_timeout_days()})")
     
     async def getStory(self, guild_id: int, story_number = 0) -> str:
         """Returns the story in the story.txt file"""

--- a/file_manager.py
+++ b/file_manager.py
@@ -57,35 +57,6 @@ class file_manager():
         with open("story.txt", "r", encoding="utf8") as f:
             self.story = f.read()
 
-    @staticmethod
-    def new_story(self, guild_id: int):
-        print(str(guild_id) + ": " + inspect.stack()[1][3])
-        """A work in progress
-        Should save the old story and restart the current story from scratch"""
-        raise NotImplementedError("The `file_manager.new_story()` command is not finished yet.")
-        
-        with open("story.txt", "r", encoding="utf8") as f:
-            old_story = f.read()
-
-        time.sleep(0.01)
-
-        backup_filename = file_manager.find_next_available_filename(guild_id)
-
-        with open(backup_filename, 'w') as f:
-            f.write(str(old_story))
-
-        with open('story.txt', 'w+') as f:
-            f.write('')
-
-    @staticmethod
-    def find_next_available_filename(guild_id: int) -> str:
-        print(str(guild_id) + ": " + inspect.stack()[1][3])
-        """This method finds the next available name for a story file and returns it"""
-        i = 1
-        while os.file.exists(f"story {i}.txt"):
-            i += 1
-
-        return f"story {i}.txt"
 
     def get_all_guild_ids(self) -> list[int]:
         # TODO: not implemented

--- a/file_manager.py
+++ b/file_manager.py
@@ -35,6 +35,17 @@ class file_manager():
     async def add_guild(self, guild_id: int) -> None:
         if not guild_id in await self.get_all_guild_ids():
             await self.db_connection.execute(f"INSERT INTO \"Guilds\" (guild_id, timeout_days) VALUES ('{guild_id}', {await self.config_manager.get_default_timeout_days()})")
+            
+    async def remove_guild(self, guild_id: int) -> None:
+        await self.db_connection.execute(f"delete from \"Users\" where guild_id = '{guild_id}'")
+        await self.db_connection.execute(f"delete from \"Logs\" where guild_id = '{guild_id}'")
+        await self.db_connection.execute(f"delete from \"Guilds\" where guild_id = '{guild_id}'")
+        try:
+            for i in range(0, await self.config_manager.get_max_archived_stories()):
+                os.remove(_get_story_file_name(guild_id, i))
+        except FileNotFoundError:
+            return
+                
     
     async def getStory(self, guild_id: int, story_number = 0) -> str:
         """Returns the story in the story.txt file"""

--- a/file_manager.py
+++ b/file_manager.py
@@ -32,7 +32,6 @@ class file_manager():
     
     
     async def getStory(self, guild_id: int, story_number = 0) -> str:
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Returns the story in the story.txt file"""
 
         story_file_name = _get_story_file_name(guild_id, story_number)
@@ -66,7 +65,6 @@ class file_manager():
         
 
     async def addLine(self, guild_id: int, line):
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Appends the given line to the story and writes it to the file"""
         
         # Makes sure the bot isn't trying to append a command onto the story
@@ -102,7 +100,6 @@ class file_manager():
         
         
     async def load_timestamp(self,  guild_id: int) -> float:
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Returns the timestamp if it exists. If it doesn't, it'll reset the timestamp and return the new one."""
 
         result = (await self.db_connection.fetchrow(f"select timestamp from \"Guilds\" where guild_id = '{guild_id}'")).get("timestamp")
@@ -115,14 +112,12 @@ class file_manager():
         
 
     async def reset_timestamp(self,  guild_id: int) -> None:
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Resets the timestamp to the current time"""
         q=datetime.now().isoformat(sep=" ", timespec="seconds")
         
         await self.db_connection.execute(f"UPDATE \"Guilds\" SET timestamp='{q}' WHERE guild_id='{guild_id}'")
         
     async def get_current_turns_of_user(self, user_id: int) -> list[int]:
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Returns all servers where it is a user's turn
 
         Args:
@@ -136,7 +131,6 @@ class file_manager():
         return result
     
     async def get_active_guilds(self, user_id: int) -> list[int]:
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Returns all servers where a user is active
 
         Args:

--- a/file_manager.py
+++ b/file_manager.py
@@ -147,7 +147,7 @@ class file_manager():
         return result
     
     async def add_user(self, user_id: int, guild_id: int):
-        if not user_id in self.get_active_users(guild_id):
+        if not user_id in await self.get_active_users(guild_id):
             await self.db_connection.execute(f"INSERT INTO \"Users\" (user_id, guild_id, reputation, is_admin) VALUES ('{user_id}', '{guild_id}', {config_manager.get_default_reputation()}, False)")
         await self.log_action(user_id=user_id, guild_id=guild_id, action="join")
     

--- a/file_manager.py
+++ b/file_manager.py
@@ -185,8 +185,22 @@ class file_manager():
         responses = await self.db_connection.fetch(f"select user_id from \"Users\" where guild_id='{guild_id}'")
         return [int(i.get("user_id")) for i in responses]
     
-    async def get_weighted_list_of_users(self, guild_id: int) -> list[int]:
-        raise NotImplementedError()
+    async def get_users_and_reputations(self, guild_id: int) -> json:
+        """Returns a json-format of all the user ids and their reputations from a server
+
+        Args:
+            guild_id (int): the guild to get user ids from
+
+        Returns:
+            json: the users in a server in a {userid (str): reputation (int)} format
+        """
+        responses = await self.db_connection.fetch(f"select user_id, reputation from \"Users\" where guild_id='{guild_id}'")
+        
+        ret = {}
+        for user in responses:
+            ret[user.get("user_id")] = user.get("reputation")
+        
+        return ret
 
 @staticmethod
 def _get_story_file_name(guild_id: int, story_number: int = 0) -> str:

--- a/file_manager.py
+++ b/file_manager.py
@@ -4,28 +4,43 @@ import os
 import time
 import config_manager
 from pathlib import Path
+import discord.file
 
 class file_manager():
-    def __init__(self):
-
-        if not Path("story.txt").is_file():
-            print("Created story.txt")
-            open("story.txt", "x").close()
-
-    def getStory(self, guild_id: int, story_number = 0):
+    def getStory(self, guild_id: int, story_number = 0) -> str:
         print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Returns the story in the story.txt file"""
         if story_number == 0:
-            with open("story.txt", "r", encoding="utf8") as file:
-                text = file.read() 
+            story_file_name = "story.txt"
         else:
-            with open("story " + str(story_number) + ".txt", "r", encoding="utf8") as file:
-                text = file.read()
+            story_file_name = "story " + str(story_number) + ".txt"
+            
+            
+        try:
+            with open(story_file_name, "r", encoding="utf8") as file:
+                text = file.read() 
+        except FileNotFoundError:
+            Path(story_file_name).touch()
+            return self.getStory(guild_id, story_number)
         
         if(text == ""):
             return "<Waiting for the first user to begin!>"
         else:
             return text
+       
+    def get_story_file(self, guild_id: int, story_number = 0) -> discord.file:
+        
+        if story_number == 0:
+            story_file_name = "story.txt"
+        else:
+            story_file_name = "story " + str(story_number) + ".txt"
+        
+        try:
+            return discord.File(story_file_name, filename=story_file_name)
+        except FileNotFoundError:
+            Path(story_file_name).touch()
+            return self.get_story_file(guild_id, story_number)
+                
 
     def addLine(self, guild_id: int, line):
         print(str(guild_id) + ": " + inspect.stack()[1][3])
@@ -36,7 +51,7 @@ class file_manager():
         if line.startswith(config_manager.get_prefix()):
             raise RuntimeWarning("I was just told to add this to the story, but this is clearly a command:\n"+line)
         
-        with open("story.txt", "a", encoding="utf8") as append_to:
+        with open("story.txt", "a+", encoding="utf8") as append_to:
             append_to.write(line)
 
         with open("story.txt", "r", encoding="utf8") as f:
@@ -101,6 +116,6 @@ def reset_timestamp(guild_id: int, filename:str = "timestamp.txt") -> float:
     print(str(guild_id) + ": " + inspect.stack()[1][3])
     """Resets the timestamp to the current time"""
     now = time.time()
-    with open(filename, "w") as f:
+    with open(filename, "w+") as f:
         f.write(str(now))
     return now

--- a/file_manager.py
+++ b/file_manager.py
@@ -11,6 +11,7 @@ class file_manager():
             open("story.txt", "x").close()
 
     def getStory(self, guild_id: int, story_number = 0):
+        print(guild_id)
         """Returns the story in the story.txt file"""
         if story_number == 0:
             with open("story.txt", "r", encoding="utf8") as file:
@@ -25,6 +26,7 @@ class file_manager():
             return text
 
     def addLine(self, guild_id: int, line):
+        print(guild_id)
         """Appends the given line to the story and writes it to the file"""
         
         # Makes sure the bot isn't trying to append a command onto the story
@@ -40,6 +42,7 @@ class file_manager():
 
     @staticmethod
     def new_story(self, guild_id: int):
+        print(guild_id)
         """A work in progress
         Should save the old story and restart the current story from scratch"""
         raise NotImplementedError("The `file_manager.new_story()` command is not finished yet.")
@@ -59,6 +62,7 @@ class file_manager():
 
     @staticmethod
     def find_next_available_filename(guild_id: int) -> str:
+        print(guild_id)
         """This method finds the next available name for a story file and returns it"""
         i = 1
         while os.file.exists(f"story {i}.txt"):
@@ -76,6 +80,7 @@ class file_manager():
 
 @staticmethod
 def load_timestamp(guild_id: int, filename: str = "timestamp.txt") -> float:
+    print(guild_id)
     """Returns the timestamp if it exists. If it doesn't, it'll reset the timestamp and return the new one."""
 
     try:
@@ -91,6 +96,7 @@ def load_timestamp(guild_id: int, filename: str = "timestamp.txt") -> float:
 
 @staticmethod
 def reset_timestamp(guild_id: int, filename:str = "timestamp.txt") -> float:
+    print(guild_id)
     """Resets the timestamp to the current time"""
     now = time.time()
     with open(filename, "w") as f:

--- a/file_manager.py
+++ b/file_manager.py
@@ -1,6 +1,6 @@
 import os
 import time
-import config
+import config_manager
 
 class file_manager():
     def __init__(self):
@@ -21,7 +21,7 @@ class file_manager():
         
         # Makes sure the bot isn't trying to append a command onto the story
         # Since this is already checked in dm_listener, this throws an error when it detects a command
-        if line.startswith(config.PREFIX):
+        if line.startswith(config_manager.get_prefix()):
             raise RuntimeWarning("I was just told to add this to the story, but this is clearly a command:\n"+line)
         
         with open("story.txt", "a", encoding="utf8") as append_to:

--- a/file_manager.py
+++ b/file_manager.py
@@ -129,7 +129,7 @@ class file_manager():
         Returns:
             list[int]: a list with all of the user's current turns
         """
-        result = (await self.db_connection.fetch(f"select guild_id from \"Guilds\" where user_id = '{user_id}'"))
+        result = (await self.db_connection.fetch(f"select guild_id from \"Guilds\" where current_user_id = '{user_id}'"))
         result = [int(i.get("guild_id")) for i in result]
         return result
     

--- a/file_manager.py
+++ b/file_manager.py
@@ -30,6 +30,8 @@ class file_manager():
         """Returns if a guild is currently participating in StoryBot"""
         return guild_id in await self.get_all_guild_ids()
     
+    async def add_guild(self, guild_id: int) -> None:
+        await self.db_connection.execute(f"INSERT INTO \"Guilds\" (guild_id, timeout_days) VALUES ('{guild_id}, {config_manager.get_timeout_days()}')")
     
     async def getStory(self, guild_id: int, story_number = 0) -> str:
         """Returns the story in the story.txt file"""

--- a/file_manager.py
+++ b/file_manager.py
@@ -90,10 +90,11 @@ class file_manager():
         
     
     async def get_current_user_id(self,  guild_id: int) -> str:
-        result = (await self.db_connection.fetchrow(f"select current_user_id from \"Guilds\" where guild_id = '{guild_id}'")).get("current_user_id")
-        if result == "0":
+        """Gets the ID of the current user of a server"""
+        result = (await self.db_connection.fetchrow(f"select current_user_id from \"Guilds\" where guild_id = '{guild_id}'"))
+        if result == None or result == "0":
             return None
-        return result
+        return result.get("current_user_id")
     
 
     async def set_current_user_id(self,  guild_id: int, user_id: int) -> str:

--- a/file_manager.py
+++ b/file_manager.py
@@ -148,12 +148,12 @@ class file_manager():
     async def add_user(self, user_id: int, guild_id: int):
         if not user_id in self.get_active_users(guild_id):
             await self.db_connection.execute(f"INSERT INTO \"Users\" (user_id, guild_id, reputation, is_admin) VALUES ('{user_id}', '{guild_id}', {config_manager.get_default_reputation()}, False)")
-        await self.log_action(self, user_id=user_id, guild_id=guild_id, action="join")
+        await self.log_action(user_id=user_id, guild_id=guild_id, action="join")
     
     async def remove_user(self, user_id: int, guild_id: int):
         """Removes a user from a given server"""
         await self.db_connection.execute(f"delete from \"Users\" where user_id='{user_id}' and guild_id='{guild_id}'")
-        await self.log_action(self, user_id=user_id, guild_id=guild_id, action="leave")
+        await self.log_action(user_id=user_id, guild_id=guild_id, action="leave")
     
     async def get_reputation(self, user_id: int, guild_id: int) -> int:
         """Returns the reputation of a given user in a given server"""

--- a/main.py
+++ b/main.py
@@ -26,6 +26,10 @@ class StoryBot(commands.Bot):
         await load_cogs(self, ["cogs.dm_listener"])
         # TODO: make this so it doesn't run every time (maybe make it a command)
         asyncio.create_task(bot.tree.sync())
+        
+        await bot.file_manager.initialize_connection()
+        
+        
 
 
 bot = StoryBot(config_manager.get_prefix(), help_command = None, intents=intents)

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import discord
 
 # create the necessary files if they don't exist
@@ -23,7 +24,8 @@ class StoryBot(commands.Bot):
         #await bot.tree.sync(guild=discord.Object(id=config.GUILD_ID))
         
         await load_cogs(self, ["cogs.dm_listener"])
-        await bot.tree.sync()
+        # TODO: make this so it doesn't run every time (maybe make it a command)
+        asyncio.create_task(bot.tree.sync())
 
 
 bot = StoryBot(config_manager.get_prefix(), help_command = None, intents=intents)

--- a/main.py
+++ b/main.py
@@ -1,15 +1,11 @@
 import asyncio
-import discord
-
-# create the necessary files if they don't exist
-
-
-        
+import discord    
 import cogs.dm_listener as dm_listener
 from user_manager import user_manager
 from file_manager import file_manager
 from config_manager import ConfigManager
 from discord.ext import commands
+import logging
 
 intents = discord.Intents.default()
 intents.guilds = True
@@ -70,6 +66,6 @@ async def load_cogs(bot: commands.Bot, cog_list: list):
         except commands.errors.NoEntryPointError:
             print("Put the setup() function back in " + cog_name + " fool.")
 
-
-bot.run(cmgr.get_token())
+handler = logging.FileHandler(filename='logs/discord.log', encoding='utf-8', mode='w')
+bot.run(cmgr.get_token(), log_handler=handler)
 

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from file_manager import file_manager
 from discord.ext import commands
 
 intents = discord.Intents.default()
+intents.guilds = True
 intents.message_content = True
 
 class StoryBot(commands.Bot):
@@ -46,7 +47,13 @@ bot.user_manager = umgr
 async def on_ready():
     print("Bot started!")
     await bot.change_presence(activity=discord.Activity(type=discord.ActivityType.watching, name=" for `/help`"))
-
+    
+@bot.event
+async def on_guild_join(guild_joined: discord.Guild):
+    await bot.file_manager.add_guild(guild_joined.id)
+    print(f"added guild {guild_joined.id}")
+    
+    
 
 async def load_cogs(bot: commands.Bot, cog_list: list):
     for cog_name in cog_list:

--- a/main.py
+++ b/main.py
@@ -18,13 +18,6 @@ intents.message_content = True
 class StoryBot(commands.Bot):
     async def setup_hook(self):
         
-        ### Notice: if the commands are showing up two times in your server but only once in DMs, uncomment these three lines for your first run ###
-        ### Then, comment them back out after this run ###
-        ### This is a fix for upgrading from v1.0.1 ###
-        #import config
-        #bot.tree.copy_global_to(guild=discord.Object(id=config.GUILD_ID))
-        #await bot.tree.sync(guild=discord.Object(id=config.GUILD_ID))
-        
         await load_cogs(self, ["cogs.dm_listener"])
         # TODO: make this so it doesn't run every time (maybe make it a command)
         asyncio.create_task(bot.tree.sync())

--- a/main.py
+++ b/main.py
@@ -1,18 +1,8 @@
 import discord
-from pathlib import Path
 
 # create the necessary files if they don't exist
 import config_manager
 
-
-if not Path("story.txt").is_file():
-    print("Created story.txt")
-    open("story.txt", "x").close()
-
-if not Path("user.txt").is_file():
-    print("Created user.txt")
-    with open("user.txt", "w") as f:
-        f.write(str(config_manager.get_default_user_ids()[0]))
         
 import cogs.dm_listener as dm_listener
 from user_manager import user_manager

--- a/main.py
+++ b/main.py
@@ -2,20 +2,7 @@ import discord
 from pathlib import Path
 
 # create the necessary files if they don't exist
-try:
-    import config
-except ModuleNotFoundError:
-    # Check if the file exists
-    # If it doesn't, copy the example file
-    from os.path import exists
-    if not exists("config.py"):
-        import shutil
-        shutil.copyfile("config.py.default", "config.py")
-        print("Please edit your config file (config.py) and then restart the bot.")
-        exit()
-    else:
-        print("Something went wrong importing the config file. Check your config file for any errors, then restart the bot.")
-        exit()
+import config_manager
 
 
 if not Path("story.txt").is_file():
@@ -25,7 +12,7 @@ if not Path("story.txt").is_file():
 if not Path("user.txt").is_file():
     print("Created user.txt")
     with open("user.txt", "w") as f:
-        f.write(str(config.DEFAULT_USER_IDS[0]))
+        f.write(str(config_manager.get_default_user_ids()[0]))
         
 import cogs.dm_listener as dm_listener
 from user_manager import user_manager
@@ -38,7 +25,10 @@ intents.message_content = True
 class StoryBot(commands.Bot):
     async def setup_hook(self):
         
-        ### Notice: if the commands are showing up two times in your server but only once in DMs, uncomment these two lines for your first run ###
+        ### Notice: if the commands are showing up two times in your server but only once in DMs, uncomment these three lines for your first run ###
+        ### Then, comment them back out after this run ###
+        ### This is a fix for upgrading from v1.0.1 ###
+        #import config
         #bot.tree.copy_global_to(guild=discord.Object(id=config.GUILD_ID))
         #await bot.tree.sync(guild=discord.Object(id=config.GUILD_ID))
         
@@ -46,7 +36,7 @@ class StoryBot(commands.Bot):
         await bot.tree.sync()
 
 
-bot = StoryBot(config.PREFIX, help_command = None, intents=intents)
+bot = StoryBot(config_manager.get_prefix(), help_command = None, intents=intents)
 
 fmgr = file_manager()
 umgr = user_manager(bot)
@@ -61,9 +51,6 @@ async def on_ready():
     print("Bot started!")
     await bot.change_presence(activity=discord.Activity(type=discord.ActivityType.watching, name=" for `/help`"))
 
-if(config.TOKEN == 'xxxxxxxxxxxxx'):
-    raise RuntimeError("Please update config.py with your bot's token!")
-
 
 async def load_cogs(bot: commands.Bot, cog_list: list):
     for cog_name in cog_list:
@@ -77,5 +64,5 @@ async def load_cogs(bot: commands.Bot, cog_list: list):
             print("Put the setup() function back in " + cog_name + " fool.")
 
 
-bot.run(config.TOKEN)
+bot.run(config_manager.get_token())
 

--- a/main.py
+++ b/main.py
@@ -2,12 +2,13 @@ import asyncio
 import discord
 
 # create the necessary files if they don't exist
-import config_manager
+
 
         
 import cogs.dm_listener as dm_listener
 from user_manager import user_manager
 from file_manager import file_manager
+from config_manager import ConfigManager
 from discord.ext import commands
 
 intents = discord.Intents.default()
@@ -31,13 +32,18 @@ class StoryBot(commands.Bot):
         await bot.file_manager.initialize_connection()
         
         
+cmgr = ConfigManager(None)
+fmgr = file_manager(cmgr)
+
+bot = StoryBot(cmgr.get_prefix(), help_command = None, intents=intents)
 
 
-bot = StoryBot(config_manager.get_prefix(), help_command = None, intents=intents)
+bot.config_manager = cmgr
 
-fmgr = file_manager()
-umgr = user_manager(bot)
+umgr = user_manager(bot, cmgr)
 dml = dm_listener.dm_listener(fmgr, umgr, bot)
+
+
 
 bot.file_manager = fmgr
 bot.user_manager = umgr
@@ -67,5 +73,5 @@ async def load_cogs(bot: commands.Bot, cog_list: list):
             print("Put the setup() function back in " + cog_name + " fool.")
 
 
-bot.run(config_manager.get_token())
+bot.run(cmgr.get_token())
 

--- a/main.py
+++ b/main.py
@@ -51,6 +51,11 @@ async def on_ready():
 async def on_guild_join(guild_joined: discord.Guild):
     await bot.file_manager.add_guild(guild_joined.id)
     print(f"added guild {guild_joined.id}")
+
+@bot.event
+async def on_guild_remove(guild_left: discord.Guild):
+    await bot.file_manager.remove_guild(guild_left.id)
+    print(f"left guild {guild_left.id}")
     
     
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 discord.py==2.1.0
+asyncpg==0.27.0

--- a/user_manager.py
+++ b/user_manager.py
@@ -23,7 +23,10 @@ class user_manager():
             ids.append(key)
             reputations.append(json_formatted[key])
         
-        new_user = int(random.choices(ids, weights=reputations)[0])
+        if(len(ids)) == 0:
+            new_user = None
+        else:
+            new_user = int(random.choices(ids, weights=reputations)[0])
         
         await self.bot.file_manager.set_current_user_id(guild_id, new_user)
         
@@ -36,7 +39,10 @@ class user_manager():
         for id in await self.get_recent_users_queue(guild_id):
             unweighted_list.remove(id)
         
-        new_user = int(random.choice(unweighted_list))
+        if(len(unweighted_list)) == 0:
+            new_user = None
+        else:
+            new_user = int(random.choice(unweighted_list))
         
         await self.bot.file_manager.set_current_user_id(guild_id, new_user)
         

--- a/user_manager.py
+++ b/user_manager.py
@@ -12,7 +12,7 @@ class user_manager():
     def __init__(self, bot):
         self.bot = bot
     
-    async def set_random_weighted_user(self, guild_id: int, add_last_user_to_queue = True) -> int:
+    async def set_random_weighted_user(self, guild_id: int) -> int:
         """Sets a random user as the current user based on their reputation"""
         json_formatted = await self.bot.file_manager.get_users_and_reputations(guild_id)
         ids = []
@@ -29,7 +29,7 @@ class user_manager():
         
         return new_user
 
-    async def set_random_unweighted_user(self, guild_id: int, add_last_user_to_queue = True) -> int:
+    async def set_random_unweighted_user(self, guild_id: int) -> int:
         """Sets a random user as the current user. Doesn't care about reputation."""
         unweighted_list = await self.get_unweighted_list(guild_id)
         

--- a/user_manager.py
+++ b/user_manager.py
@@ -1,23 +1,23 @@
 import secrets
 import os
-import config
 import collections
 import json
+import config_manager
 
 class user_manager():
     def __init__(self, bot):
         self.bot = bot
         
-        # Create the initial list of users
+        # Create the initial list of users 
         try:
             with open('weighted list of users.json', 'rt') as f:
                 self.weighted_list_of_users = json.load(f)
             for id in self.weighted_list_of_users:
-                while(collections.Counter(self.weighted_list_of_users)[id] > config.MAX_REPUTATION):
+                while(collections.Counter(self.weighted_list_of_users)[id] > config_manager.get_max_reputation(None)):
                     self.unboost_user(id)
         except:
             self.weighted_list_of_users = []
-            for item in config.DEFAULT_USER_IDS:
+            for item in config_manager.get_default_user_ids():
                 self.add_user(item)
             self.serialize()
                 
@@ -26,7 +26,7 @@ class user_manager():
         try:
             with open('recent_users.json', 'rt') as f:
                 self.recent_users = json.load(f)
-            while len(self.recent_users) > config.LAST_N_PLAYERS_NO_REPEAT:
+            while len(self.recent_users) > config_manager.get_amount_to_not_repeat():
                 self.pop_from_recent_users_queue()
         except:
             self.recent_users = []
@@ -66,7 +66,7 @@ class user_manager():
         
         internalListToChooseFrom = listToChooseFrom
 
-        if config.LAST_N_PLAYERS_NO_REPEAT > 0:
+        if config_manager.get_amount_to_not_repeat() > 0:
             # Makes sure the same user isn't chosen more than once in a row, even if the most recent user wasn't added to the queue (like in a skip)
             internalListToChooseFrom = user_manager.remove_all_occurrences(internalListToChooseFrom, user_manager.get_current_user())
                 
@@ -101,7 +101,7 @@ class user_manager():
     def add_user(self, id):
         """Adds the given user to the list of users"""
         if id not in self.get_weighted_list():
-            for i in range(0, config.DEFAULT_REPUTATION):
+            for i in range(0, config_manager.get_default_reputation(None)):
                 self.weighted_list_of_users.append(id)
         self.serialize()
 
@@ -113,7 +113,7 @@ class user_manager():
 
     def boost_user(self, id):
         """Boosts the given user's reputation"""
-        if(collections.Counter(self.weighted_list_of_users)[id] < config.MAX_REPUTATION):
+        if(collections.Counter(self.weighted_list_of_users)[id] < config_manager.get_max_reputation(None)):
             self.weighted_list_of_users.append(id)
         self.serialize()
         print('boosted {0} finished'.format(id))
@@ -146,15 +146,15 @@ class user_manager():
         self.serialize_queue()
         
     def add_to_recent_users_queue(self, id: int) -> None:
-        """Adds a given user ID to the list of recent users. Pops the first user if the list's length is longer than `config.LAST_N_PLAYERS_NO_REPEAT`
+        """Adds a given user ID to the list of recent users. Pops the first user if the list's length is longer than `LAST_N_PLAYERS_NO_REPEAT`
 
         Args:
             id (int): the user ID to add to the recent user queue
         """
         self.recent_users.append(id)
         
-        if(self.recent_users_queue_size() > config.LAST_N_PLAYERS_NO_REPEAT):
-            while(self.recent_users_queue_size() > config.LAST_N_PLAYERS_NO_REPEAT):
+        if(self.recent_users_queue_size() > config_manager.get_amount_to_not_repeat()):
+            while(self.recent_users_queue_size() > config_manager.get_amount_to_not_repeat()):
                 self.pop_from_recent_users_queue()
         
             # There's no need to serialize here since pop_recent_queue() serializes automatically

--- a/user_manager.py
+++ b/user_manager.py
@@ -22,7 +22,6 @@ class user_manager():
         
     
     async def set_random_weighted_user(self, guild_id: int, add_last_user_to_queue = True) -> int:
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Sets a random user as the current user based on their reputation"""
         if add_last_user_to_queue:
             current_user = await self.get_current_user(guild_id)
@@ -32,7 +31,6 @@ class user_manager():
         return await self.__set_new_random_user(await self.get_weighted_list(guild_id), guild_id)
 
     async def set_random_unweighted_user(self, guild_id: int, add_last_user_to_queue = True) -> int:
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Sets a random user as the current user. Doesn't care about reputation."""
         if add_last_user_to_queue:
             self.add_to_recent_users_queue(guild_id, int(await self.get_current_user(guild_id)))
@@ -82,7 +80,6 @@ class user_manager():
 
 
     async def get_current_user(self, guild_id: int) -> str:
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Returns the current user's id as a string"""
         ret = await self.bot.file_manager.get_current_user_id(guild_id)
         if ret == "":
@@ -91,33 +88,27 @@ class user_manager():
             return ret
 
     async def add_user(self, guild_id: int, user_id):
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Adds the given user to the list of users"""
         await self.bot.file_manager.add_user(user_id=user_id, guild_id=guild_id)
 
     async def remove_user(self, guild_id: int, user_id):
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Removes the given user from the list of users"""
         await self.bot.file_manager.remove_user(user_id=user_id, guild_id=guild_id)
 
     async def boost_user(self, guild_id: int, user_id):
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Boosts the given user's reputation"""
         
         await self.bot.file_manager.alter_reputation(user_id=user_id, guild_id=guild_id, amount=1)
         
     async def unboost_user(self, guild_id: int, user_id):
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Reduces the given user's reputation"""
         
         await self.bot.file_manager.alter_reputation(user_id=user_id, guild_id=guild_id, amount=-1)
 
     async def get_weighted_list(self, guild_id: int) -> list[int]:
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         return await self.bot.file_manager.get_weighted_list_of_users(guild_id)
 
     async def get_unweighted_list(self, guild_id: int) -> list[int]:
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         return await self.bot.file_manager.get_active_users(guild_id)
 
 
@@ -127,7 +118,6 @@ class user_manager():
     ######################################
     
     def pop_from_recent_users_queue(self, guild_id: int) -> None:
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Removes the first user from the list of recent users"""
         try:
             self.recent_users.pop(0)
@@ -136,7 +126,6 @@ class user_manager():
         self.serialize_queue()
         
     def add_to_recent_users_queue(self, guild_id: int, user_id: int) -> None:
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Adds a given user ID to the list of recent users. Pops the first user if the list's length is longer than `LAST_N_PLAYERS_NO_REPEAT`
 
         Args:
@@ -154,12 +143,10 @@ class user_manager():
             
             
     def recent_users_queue_size(self, guild_id: int) -> int:
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Returns the size of the list of recent users"""
         return len(self.recent_users)
             
     def is_recent_user(self, guild_id: int, user_id: int) -> bool:
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Returns if a user is in the list of recent users
 
         Args:
@@ -172,7 +159,6 @@ class user_manager():
         return user_id in self.recent_users
     
     def get_recent_users_queue(self, guild_id: int) -> list:
-        # print(str(guild_id) + ": " + inspect.stack()[1][3])
         return self.recent_users
 
         

--- a/user_manager.py
+++ b/user_manager.py
@@ -5,12 +5,13 @@ import random
 import os
 import collections
 import json
-import config_manager
+from config_manager import ConfigManager
 import asyncio
 
 class user_manager():
-    def __init__(self, bot):
+    def __init__(self, bot, config_manager: ConfigManager):
         self.bot = bot
+        self.config_manager = config_manager
     
     async def set_random_weighted_user(self, guild_id: int) -> int:
         """Sets a random user as the current user based on their reputation"""

--- a/user_manager.py
+++ b/user_manager.py
@@ -52,7 +52,7 @@ class user_manager():
     async def get_current_user(self, guild_id: int) -> str:
         """Returns the current user's id as a string"""
         ret = await self.bot.file_manager.get_current_user_id(guild_id)
-        if ret == "":
+        if ret == "" or ret == "0":
             return None
         else:
             return ret

--- a/user_manager.py
+++ b/user_manager.py
@@ -37,6 +37,7 @@ class user_manager():
         
     
     def set_random_weighted_user(self, guild_id: int, add_last_user_to_queue = True) -> int:
+        print(guild_id)
         """Sets a random user as the current user based on their reputation"""
         if add_last_user_to_queue:
             self.add_to_recent_users_queue(guild_id, int(user_manager.get_current_user(guild_id)))
@@ -44,6 +45,7 @@ class user_manager():
         return self.__set_new_random_user(self.get_weighted_list(guild_id), guild_id)
 
     def set_random_unweighted_user(self, guild_id: int, add_last_user_to_queue = True) -> int:
+        print(guild_id)
         """Sets a random user as the current user. Doesn't care about reputation."""
         if add_last_user_to_queue:
             self.add_to_recent_users_queue(guild_id, int(user_manager.get_current_user(guild_id)))
@@ -95,6 +97,7 @@ class user_manager():
 
     @staticmethod
     def get_current_user(guild_id: int) -> str:
+        print(guild_id)
         """Returns the current user"""
         file = open("user.txt", "r")
         currentUserID = file.read()
@@ -102,6 +105,7 @@ class user_manager():
         return currentUserID
 
     def add_user(self, guild_id: int, user_id):
+        print(guild_id)
         """Adds the given user to the list of users"""
         if user_id not in self.get_weighted_list(guild_id):
             for i in range(0, config_manager.get_default_reputation(guild_id)):
@@ -109,12 +113,14 @@ class user_manager():
         self.serialize()
 
     def remove_user(self, guild_id: int, user_id):
+        print(guild_id)
         """Removes the given user from the list of users"""
         for i in range(0, collections.Counter(self.weighted_list_of_users)[user_id]):
             self.weighted_list_of_users.remove(user_id)
         self.serialize()
 
     def boost_user(self, guild_id: int, user_id):
+        print(guild_id)
         """Boosts the given user's reputation"""
         if(collections.Counter(self.weighted_list_of_users)[user_id] < config_manager.get_max_reputation(user_id)):
             self.weighted_list_of_users.append(user_id)
@@ -122,6 +128,7 @@ class user_manager():
         print('boosted {0} finished'.format(user_id))
 
     def unboost_user(self, guild_id: int, user_id):
+        print(guild_id)
         """Reduces the given user's reputation"""
         if(collections.Counter(self.weighted_list_of_users)[user_id] > 2):
             self.weighted_list_of_users.remove(user_id)
@@ -129,9 +136,11 @@ class user_manager():
         print('unboosted {0} successful'.format(user_id))
 
     def get_weighted_list(self, guild_id: int):
+        print(guild_id)
         return self.weighted_list_of_users
 
     def get_unweighted_list(self, guild_id: int):
+        print(guild_id)
         return set(self.weighted_list_of_users)
 
 
@@ -141,6 +150,7 @@ class user_manager():
     ######################################
     
     def pop_from_recent_users_queue(self, guild_id: int) -> None:
+        print(guild_id)
         """Removes the first user from the list of recent users"""
         try:
             self.recent_users.pop(0)
@@ -149,6 +159,7 @@ class user_manager():
         self.serialize_queue()
         
     def add_to_recent_users_queue(self, guild_id: int, user_id: int) -> None:
+        print(guild_id)
         """Adds a given user ID to the list of recent users. Pops the first user if the list's length is longer than `LAST_N_PLAYERS_NO_REPEAT`
 
         Args:
@@ -166,10 +177,12 @@ class user_manager():
             
             
     def recent_users_queue_size(self, guild_id: int) -> int:
+        print(guild_id)
         """Returns the size of the list of recent users"""
         return len(self.recent_users)
             
     def is_recent_user(self, guild_id: int, user_id: int) -> bool:
+        print(guild_id)
         """Returns if a user is in the list of recent users
 
         Args:
@@ -182,6 +195,7 @@ class user_manager():
         return user_id in self.recent_users
     
     def get_recent_users_queue(self, guild_id: int) -> list:
+        print(guild_id)
         return self.recent_users
     
     

--- a/user_manager.py
+++ b/user_manager.py
@@ -3,10 +3,16 @@ import os
 import collections
 import json
 import config_manager
+from pathlib import Path
 
 class user_manager():
     def __init__(self, bot):
         self.bot = bot
+        
+        if not Path("user.txt").is_file():
+            print("Created user.txt")
+            with open("user.txt", "w") as f:
+                f.write(str(config_manager.get_default_user_ids()[0]))
         
         # Create the initial list of users 
         try:

--- a/user_manager.py
+++ b/user_manager.py
@@ -23,6 +23,7 @@ class user_manager():
     
     async def set_random_weighted_user(self, guild_id: int, add_last_user_to_queue = True) -> int:
         """Sets a random user as the current user based on their reputation"""
+        raise NotImplementedError()
         if add_last_user_to_queue:
             current_user = await self.get_current_user(guild_id)
             if current_user != None:
@@ -32,6 +33,7 @@ class user_manager():
 
     async def set_random_unweighted_user(self, guild_id: int, add_last_user_to_queue = True) -> int:
         """Sets a random user as the current user. Doesn't care about reputation."""
+        raise NotImplementedError()
         if add_last_user_to_queue:
             self.add_to_recent_users_queue(guild_id, int(await self.get_current_user(guild_id)))
             
@@ -39,6 +41,7 @@ class user_manager():
     
     
     async def __set_new_random_user(self, listToChooseFrom:list, guild_id = int) -> int:
+        raise NotImplementedError()
         """Sets a random user from the list as the current user
 
         Args:

--- a/user_manager.py
+++ b/user_manager.py
@@ -98,7 +98,7 @@ class user_manager():
     def add_user(self, guild_id: int, user_id):
         """Adds the given user to the list of users"""
         if user_id not in self.get_weighted_list(guild_id):
-            for i in range(0, config_manager.get_default_reputation(None)):
+            for i in range(0, config_manager.get_default_reputation(guild_id)):
                 self.weighted_list_of_users.append(user_id)
         self.serialize()
 
@@ -110,7 +110,7 @@ class user_manager():
 
     def boost_user(self, guild_id: int, user_id):
         """Boosts the given user's reputation"""
-        if(collections.Counter(self.weighted_list_of_users)[user_id] < config_manager.get_max_reputation(None)):
+        if(collections.Counter(self.weighted_list_of_users)[user_id] < config_manager.get_max_reputation(user_id)):
             self.weighted_list_of_users.append(user_id)
         self.serialize()
         print('boosted {0} finished'.format(user_id))

--- a/user_manager.py
+++ b/user_manager.py
@@ -1,3 +1,5 @@
+import inspect
+
 import secrets
 import os
 import collections
@@ -37,7 +39,7 @@ class user_manager():
         
     
     def set_random_weighted_user(self, guild_id: int, add_last_user_to_queue = True) -> int:
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Sets a random user as the current user based on their reputation"""
         if add_last_user_to_queue:
             self.add_to_recent_users_queue(guild_id, int(user_manager.get_current_user(guild_id)))
@@ -45,7 +47,7 @@ class user_manager():
         return self.__set_new_random_user(self.get_weighted_list(guild_id), guild_id)
 
     def set_random_unweighted_user(self, guild_id: int, add_last_user_to_queue = True) -> int:
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Sets a random user as the current user. Doesn't care about reputation."""
         if add_last_user_to_queue:
             self.add_to_recent_users_queue(guild_id, int(user_manager.get_current_user(guild_id)))
@@ -97,7 +99,7 @@ class user_manager():
 
     @staticmethod
     def get_current_user(guild_id: int) -> str:
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Returns the current user"""
         file = open("user.txt", "r")
         currentUserID = file.read()
@@ -105,7 +107,7 @@ class user_manager():
         return currentUserID
 
     def add_user(self, guild_id: int, user_id):
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Adds the given user to the list of users"""
         if user_id not in self.get_weighted_list(guild_id):
             for i in range(0, config_manager.get_default_reputation(guild_id)):
@@ -113,14 +115,14 @@ class user_manager():
         self.serialize()
 
     def remove_user(self, guild_id: int, user_id):
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Removes the given user from the list of users"""
         for i in range(0, collections.Counter(self.weighted_list_of_users)[user_id]):
             self.weighted_list_of_users.remove(user_id)
         self.serialize()
 
     def boost_user(self, guild_id: int, user_id):
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Boosts the given user's reputation"""
         if(collections.Counter(self.weighted_list_of_users)[user_id] < config_manager.get_max_reputation(user_id)):
             self.weighted_list_of_users.append(user_id)
@@ -128,7 +130,7 @@ class user_manager():
         print('boosted {0} finished'.format(user_id))
 
     def unboost_user(self, guild_id: int, user_id):
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Reduces the given user's reputation"""
         if(collections.Counter(self.weighted_list_of_users)[user_id] > 2):
             self.weighted_list_of_users.remove(user_id)
@@ -136,11 +138,11 @@ class user_manager():
         print('unboosted {0} successful'.format(user_id))
 
     def get_weighted_list(self, guild_id: int):
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         return self.weighted_list_of_users
 
     def get_unweighted_list(self, guild_id: int):
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         return set(self.weighted_list_of_users)
 
 
@@ -150,7 +152,7 @@ class user_manager():
     ######################################
     
     def pop_from_recent_users_queue(self, guild_id: int) -> None:
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Removes the first user from the list of recent users"""
         try:
             self.recent_users.pop(0)
@@ -159,7 +161,7 @@ class user_manager():
         self.serialize_queue()
         
     def add_to_recent_users_queue(self, guild_id: int, user_id: int) -> None:
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Adds a given user ID to the list of recent users. Pops the first user if the list's length is longer than `LAST_N_PLAYERS_NO_REPEAT`
 
         Args:
@@ -177,12 +179,12 @@ class user_manager():
             
             
     def recent_users_queue_size(self, guild_id: int) -> int:
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Returns the size of the list of recent users"""
         return len(self.recent_users)
             
     def is_recent_user(self, guild_id: int, user_id: int) -> bool:
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Returns if a user is in the list of recent users
 
         Args:
@@ -195,7 +197,7 @@ class user_manager():
         return user_id in self.recent_users
     
     def get_recent_users_queue(self, guild_id: int) -> list:
-        print(guild_id)
+        print(str(guild_id) + ": " + inspect.stack()[1][3])
         return self.recent_users
     
     

--- a/user_manager.py
+++ b/user_manager.py
@@ -12,13 +12,11 @@ class user_manager():
         try:
             with open('weighted list of users.json', 'rt') as f:
                 self.weighted_list_of_users = json.load(f)
-            for id in self.weighted_list_of_users:
-                while(collections.Counter(self.weighted_list_of_users)[id] > config_manager.get_max_reputation(None)):
-                    self.unboost_user(id)
+            # TODO: make sure no user is in the list too often
         except:
             self.weighted_list_of_users = []
             for item in config_manager.get_default_user_ids():
-                self.add_user(item)
+                self.add_user(config_manager.get_default_guild_id(), item)
             self.serialize()
                 
                 
@@ -26,29 +24,28 @@ class user_manager():
         try:
             with open('recent_users.json', 'rt') as f:
                 self.recent_users = json.load(f)
-            while len(self.recent_users) > config_manager.get_amount_to_not_repeat():
-                self.pop_from_recent_users_queue()
+            # TODO: check if any user is in the list of recent users more often than the maximum
         except:
             self.recent_users = []
             self.serialize_queue()
         
     
-    def set_random_weighted_user(self, add_last_user_to_queue = True) -> int:
+    def set_random_weighted_user(self, guild_id: int, add_last_user_to_queue = True) -> int:
         """Sets a random user as the current user based on their reputation"""
         if add_last_user_to_queue:
-            self.add_to_recent_users_queue(int(user_manager.get_current_user()))
+            self.add_to_recent_users_queue(guild_id, int(user_manager.get_current_user(guild_id)))
         
-        return self.__set_new_random_user(self.get_weighted_list())
+        return self.__set_new_random_user(self.get_weighted_list(guild_id), guild_id)
 
-    def set_random_unweighted_user(self, add_last_user_to_queue = True) -> int:
+    def set_random_unweighted_user(self, guild_id: int, add_last_user_to_queue = True) -> int:
         """Sets a random user as the current user. Doesn't care about reputation."""
         if add_last_user_to_queue:
-            self.add_to_recent_users_queue(int(user_manager.get_current_user()))
+            self.add_to_recent_users_queue(guild_id, int(user_manager.get_current_user(guild_id)))
             
-        return self.__set_new_random_user(self.get_unweighted_list())
+        return self.__set_new_random_user(self.get_unweighted_list(guild_id), guild_id)
     
     
-    def __set_new_random_user(self, listToChooseFrom:list) -> int:
+    def __set_new_random_user(self, listToChooseFrom:list, guild_id = int) -> int:
         """Sets a random user from the list as the current user
 
         Args:
@@ -68,17 +65,17 @@ class user_manager():
 
         if config_manager.get_amount_to_not_repeat() > 0:
             # Makes sure the same user isn't chosen more than once in a row, even if the most recent user wasn't added to the queue (like in a skip)
-            internalListToChooseFrom = user_manager.remove_all_occurrences(internalListToChooseFrom, user_manager.get_current_user())
+            internalListToChooseFrom = user_manager.remove_all_occurrences(internalListToChooseFrom, user_manager.get_current_user(guild_id))
                 
             # Makes sure that the chosen user isn't in the recent users queue
-            for item in self.get_recent_users_queue():
+            for item in self.get_recent_users_queue(guild_id):
                 internalListToChooseFrom = user_manager.remove_all_occurrences(internalListToChooseFrom, item)
             
         
         # If there's too many people on the recent user queue, pop the most recent and try again. That way, it'll go in sequential order
         if(len(internalListToChooseFrom) < 1):
-            self.pop_from_recent_users_queue()
-            return self.__set_new_random_user(listToChooseFrom)
+            self.pop_from_recent_users_queue(guild_id)
+            return self.__set_new_random_user(listToChooseFrom, guild_id)
         
         new_user = secrets.choice(internalListToChooseFrom)
         
@@ -91,44 +88,44 @@ class user_manager():
 
 
     @staticmethod
-    def get_current_user() -> str:
+    def get_current_user(guild_id: int) -> str:
         """Returns the current user"""
         file = open("user.txt", "r")
         currentUserID = file.read()
         file.close()
         return currentUserID
 
-    def add_user(self, id):
+    def add_user(self, guild_id: int, user_id):
         """Adds the given user to the list of users"""
-        if id not in self.get_weighted_list():
+        if user_id not in self.get_weighted_list(guild_id):
             for i in range(0, config_manager.get_default_reputation(None)):
-                self.weighted_list_of_users.append(id)
+                self.weighted_list_of_users.append(user_id)
         self.serialize()
 
-    def remove_user(self, id):
+    def remove_user(self, guild_id: int, user_id):
         """Removes the given user from the list of users"""
-        for i in range(0, collections.Counter(self.weighted_list_of_users)[id]):
-            self.weighted_list_of_users.remove(id)
+        for i in range(0, collections.Counter(self.weighted_list_of_users)[user_id]):
+            self.weighted_list_of_users.remove(user_id)
         self.serialize()
 
-    def boost_user(self, id):
+    def boost_user(self, guild_id: int, user_id):
         """Boosts the given user's reputation"""
-        if(collections.Counter(self.weighted_list_of_users)[id] < config_manager.get_max_reputation(None)):
-            self.weighted_list_of_users.append(id)
+        if(collections.Counter(self.weighted_list_of_users)[user_id] < config_manager.get_max_reputation(None)):
+            self.weighted_list_of_users.append(user_id)
         self.serialize()
-        print('boosted {0} finished'.format(id))
+        print('boosted {0} finished'.format(user_id))
 
-    def unboost_user(self, id):
+    def unboost_user(self, guild_id: int, user_id):
         """Reduces the given user's reputation"""
-        if(collections.Counter(self.weighted_list_of_users)[id] > 2):
-            self.weighted_list_of_users.remove(id)
+        if(collections.Counter(self.weighted_list_of_users)[user_id] > 2):
+            self.weighted_list_of_users.remove(user_id)
         self.serialize()
-        print('unboosted {0} successful'.format(id))
+        print('unboosted {0} successful'.format(user_id))
 
-    def get_weighted_list(self):
+    def get_weighted_list(self, guild_id: int):
         return self.weighted_list_of_users
 
-    def get_unweighted_list(self):
+    def get_unweighted_list(self, guild_id: int):
         return set(self.weighted_list_of_users)
 
 
@@ -137,7 +134,7 @@ class user_manager():
     # These should probably be in their own class, but since this implementation may be changing when multi server support is added, I decided to just put them in here for now.
     ######################################
     
-    def pop_from_recent_users_queue(self) -> None:
+    def pop_from_recent_users_queue(self, guild_id: int) -> None:
         """Removes the first user from the list of recent users"""
         try:
             self.recent_users.pop(0)
@@ -145,40 +142,40 @@ class user_manager():
             pass
         self.serialize_queue()
         
-    def add_to_recent_users_queue(self, id: int) -> None:
+    def add_to_recent_users_queue(self, guild_id: int, user_id: int) -> None:
         """Adds a given user ID to the list of recent users. Pops the first user if the list's length is longer than `LAST_N_PLAYERS_NO_REPEAT`
 
         Args:
             id (int): the user ID to add to the recent user queue
         """
-        self.recent_users.append(id)
+        self.recent_users.append(user_id)
         
-        if(self.recent_users_queue_size() > config_manager.get_amount_to_not_repeat()):
-            while(self.recent_users_queue_size() > config_manager.get_amount_to_not_repeat()):
-                self.pop_from_recent_users_queue()
+        if(self.recent_users_queue_size(guild_id) > config_manager.get_amount_to_not_repeat()):
+            while(self.recent_users_queue_size(guild_id) > config_manager.get_amount_to_not_repeat()):
+                self.pop_from_recent_users_queue(guild_id)
         
             # There's no need to serialize here since pop_recent_queue() serializes automatically
         else:
             self.serialize_queue()
             
             
-    def recent_users_queue_size(self) -> int:
+    def recent_users_queue_size(self, guild_id: int) -> int:
         """Returns the size of the list of recent users"""
         return len(self.recent_users)
             
-    def is_recent_user(self, id: int) -> bool:
+    def is_recent_user(self, guild_id: int, user_id: int) -> bool:
         """Returns if a user is in the list of recent users
 
         Args:
-            id (int): the user id to check
+            user_id (int): the user id to check
 
         Returns:
             bool: whether the user is a recent user
         """
         
-        return id in self.recent_users
+        return user_id in self.recent_users
     
-    def get_recent_users_queue(self) -> list:
+    def get_recent_users_queue(self, guild_id: int) -> list:
         return self.recent_users
     
     

--- a/user_manager.py
+++ b/user_manager.py
@@ -124,7 +124,7 @@ class user_manager():
     def boost_user(self, guild_id: int, user_id):
         print(str(guild_id) + ": " + inspect.stack()[1][3])
         """Boosts the given user's reputation"""
-        if(collections.Counter(self.weighted_list_of_users)[user_id] < config_manager.get_max_reputation(user_id)):
+        if(collections.Counter(self.weighted_list_of_users)[user_id] < config_manager.get_max_reputation(guild_id)):
             self.weighted_list_of_users.append(user_id)
         self.serialize()
         print('boosted {0} finished'.format(user_id))

--- a/user_manager.py
+++ b/user_manager.py
@@ -66,6 +66,7 @@ class user_manager():
         """
         
         if len(listToChooseFrom) == 0:
+            await self.bot.file_manager.set_current_user_id(guild_id, None)
             raise ValueError("No users passed to `__set_new_random_user`")
         
         internalListToChooseFrom = listToChooseFrom
@@ -94,7 +95,7 @@ class user_manager():
 
     async def get_current_user(self, guild_id: int) -> str:
         # print(str(guild_id) + ": " + inspect.stack()[1][3])
-        """Returns the current user"""
+        """Returns the current user's id as a string"""
         ret = await self.bot.file_manager.get_current_user_id(guild_id)
         if ret == "":
             return None


### PR DESCRIPTION
- [x] #2, but for individual servers:
  - [x] Add guild_id as a parameter to a bunch of methods
  - [x] State (current user, story, etc.)
    - [x] `file_manager` - 075fc79047532d0ddfc9799b4ed5f2dd2e527dbf
    - [x] Make `user_manager` use `file_manager` for all database access or make it access the database directly
      - [x] Implement the weighted users queue in file_manager - c96de9378edd973000623281a5ce0391ba848f11
      - [x] Implement everything else in file_manager
    - [x] Make `config_manager` use `file_manager` for all database access or make it access the database directly
    - [x] Change user weighted randomness from being a list (which isn't as efficient) to being stored as numbers (for a weighted average) - c96de9378edd973000623281a5ce0391ba848f11
- [x] #35 
- [x] #29 
- [ ] If the bot is removed from a server, it should delete all relevant story data for that server
- [x] If it's your turn on multiple servers, then you need to be able to select which server you want to add to

#25, #28, #35 can be implemented later; this is just to get bare bones multi-server support working without any bugs. Improvements will be made later

Will fix #23, #10